### PR TITLE
[fix] 트렌드 스코어 pickRate 0 가중치 재분배 및 꿀챔 스코어 최소 게임 수 필터 적용

### DIFF
--- a/frontend/src/app/api/meta/honey-picks/route.ts
+++ b/frontend/src/app/api/meta/honey-picks/route.ts
@@ -150,11 +150,14 @@ export async function GET(request: NextRequest) {
     // 이전 패치 데이터를 characterNum 기준 Map
     const prevMap = new Map(prevRates.map((r) => [r.characterNum, r]));
 
-    // 꿀챔 필터: 승률 ↑ 필수 (픽률은 무관)
+    // 꿀챔 필터: 승률 ↑ 필수 (픽률은 무관), 소표본 제외
+    const MIN_GAMES_CURRENT = 20;
+    const MIN_GAMES_PREV = 10;
     const honeyPicks: HoneyPickData[] = [];
     for (const curr of currentRates) {
+      if (curr.totalGames < MIN_GAMES_CURRENT) continue;
       const prev = prevMap.get(curr.characterNum);
-      if (!prev) continue;
+      if (!prev || prev.totalGames < MIN_GAMES_PREV) continue;
 
       const pickRateDelta = curr.pickRate - prev.pickRate;
       const winRateDelta = curr.winRate - prev.winRate;

--- a/frontend/src/utils/metaAnalysis.ts
+++ b/frontend/src/utils/metaAnalysis.ts
@@ -59,11 +59,16 @@ export function calculateTrendScore(
   // 예: 평균 RP 10 증가 → 정규화 값 약 20
   const normalizedRP = (changes.averageRP.delta / 50) * 100;
 
+  // pickRate가 0이면 30% 가중치가 무효화되므로 winRate/averageRP에 재분배
+  const effectiveWeights = changes.pickRate.current > 0 || changes.pickRate.previous > 0
+    ? weights
+    : { winRate: 0.55, pickRate: 0, averageRP: 0.45 };
+
   // 가중 평균 계산
   const score =
-    normalizedWinRate * weights.winRate +
-    normalizedPickRate * weights.pickRate +
-    normalizedRP * weights.averageRP;
+    normalizedWinRate * effectiveWeights.winRate +
+    normalizedPickRate * effectiveWeights.pickRate +
+    normalizedRP * effectiveWeights.averageRP;
 
   // -100 ~ 100 범위로 제한
   return Math.max(-100, Math.min(100, score));


### PR DESCRIPTION
## 변경 사항
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.


## 테스트 결과 (테스트를 했으면)
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.