### PR TITLE
[fix] 캐릭터 분석 페이지 ISR 미적용 수정

### DIFF
--- a/frontend/src/app/(default)/character/[code]/page.tsx
+++ b/frontend/src/app/(default)/character/[code]/page.tsx
@@ -13,6 +13,7 @@ import { getStaticTranslator, OG_LOCALE_BY_LANGUAGE } from "@/lib/staticIntl";
 import { TierGroup } from "@/utils/tier";
 
 export const revalidate = 3600;
+export const dynamic = "force-static";
 export const dynamicParams = false;
 
 interface Props {

--- a/frontend/src/app/(site)/[locale]/character/[code]/page.tsx
+++ b/frontend/src/app/(site)/[locale]/character/[code]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
 import { CharacterPageContent } from "@/components/features/character-analysis/CharacterPageContent";
 import { CHARACTER_CODES } from "@/components/features/character-analysis/constants";
 import { getAllPatchVersions } from "@/data/patch-notes";
@@ -13,6 +14,7 @@ import { getStaticTranslator, OG_LOCALE_BY_LANGUAGE } from "@/lib/staticIntl";
 import { TierGroup } from "@/utils/tier";
 
 export const revalidate = 3600;
+export const dynamic = "force-static";
 export const dynamicParams = false;
 
 interface Props {
@@ -111,6 +113,8 @@ export default async function LocalizedCharacterPage({ params }: Props) {
   if (!isRouteLocale(locale)) {
     notFound();
   }
+
+  setRequestLocale(locale);
 
   const code = parseInt(rawCode, 10);
 

--- a/frontend/src/app/(site)/[locale]/layout.tsx
+++ b/frontend/src/app/(site)/[locale]/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
 import "../../globals.css";
 import type { ReactNode } from "react";
 import { AppFrame } from "@/components/AppFrame";
@@ -37,6 +38,8 @@ export default async function LocaleLayout({ children, params }: LocaleLayoutPro
   if (!isRouteLocale(locale)) {
     notFound();
   }
+
+  setRequestLocale(locale);
 
   const language = LANGUAGE_BY_ROUTE_LOCALE[locale];
   const initialMessages = await loadIntlMessages(language);

--- a/frontend/src/app/(site)/[locale]/page.tsx
+++ b/frontend/src/app/(site)/[locale]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
 import { HomePageContent } from "@/components/features/home/HomePageContent";
 import { LANGUAGE_BY_ROUTE_LOCALE, ROUTE_LOCALES, isRouteLocale } from "@/i18n/routing";
 import { getPatches } from "@/lib/getPatches";
@@ -70,6 +71,8 @@ export default async function LocalizedHomePage({ params }: LocalePageProps) {
   if (!isRouteLocale(locale)) {
     notFound();
   }
+
+  setRequestLocale(locale);
 
   const defaultTier = "MITHRIL";
   const emptyRankingData: Awaited<ReturnType<typeof fetchRankingData>> = {

--- a/frontend/src/app/(site)/[locale]/patches/[version]/page.tsx
+++ b/frontend/src/app/(site)/[locale]/patches/[version]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
 import { ROUTE_LOCALES, isRouteLocale } from "@/i18n/routing";
 import { localizeMetadata } from "@/lib/routeMetadata";
 import PatchDetailPage, {
@@ -40,6 +41,8 @@ export default async function LocalizedPatchDetailPage({ params }: LocalePagePro
   if (!isRouteLocale(locale)) {
     notFound();
   }
+
+  setRequestLocale(locale);
 
   return <PatchDetailPage params={Promise.resolve({ version })} />;
 }

--- a/frontend/src/app/(site)/[locale]/patches/[version]/page.tsx
+++ b/frontend/src/app/(site)/[locale]/patches/[version]/page.tsx
@@ -12,6 +12,7 @@ interface LocalePageProps {
   params: Promise<{ locale: string; version: string }>;
 }
 
+export const dynamic = "force-static";
 export const dynamicParams = false;
 export const revalidate = 3600;
 

--- a/frontend/src/app/(site)/[locale]/patches/page.tsx
+++ b/frontend/src/app/(site)/[locale]/patches/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
 import { isRouteLocale } from "@/i18n/routing";
 import { localizeMetadata } from "@/lib/routeMetadata";
 import PatchesIndexPage, {
@@ -22,4 +23,14 @@ export async function generateMetadata({ params }: LocalePageProps): Promise<Met
   return localizeMetadata(await generateBaseMetadata(), "/patches", locale);
 }
 
-export default PatchesIndexPage;
+export default async function LocalizedPatchesIndexPage({ params }: LocalePageProps) {
+  const { locale } = await params;
+
+  if (!isRouteLocale(locale)) {
+    notFound();
+  }
+
+  setRequestLocale(locale);
+
+  return <PatchesIndexPage />;
+}

--- a/frontend/src/app/(site)/[locale]/privacy/page.tsx
+++ b/frontend/src/app/(site)/[locale]/privacy/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
 import { isRouteLocale } from "@/i18n/routing";
 import { localizeMetadata } from "@/lib/routeMetadata";
 import PrivacyPage, { metadata as baseMetadata } from "@/views/legal/PrivacyPage";
@@ -18,4 +19,14 @@ export async function generateMetadata({ params }: LocalePageProps): Promise<Met
   return localizeMetadata(baseMetadata, "/privacy", locale);
 }
 
-export default PrivacyPage;
+export default async function LocalizedPrivacyPage({ params }: LocalePageProps) {
+  const { locale } = await params;
+
+  if (!isRouteLocale(locale)) {
+    notFound();
+  }
+
+  setRequestLocale(locale);
+
+  return <PrivacyPage />;
+}

--- a/frontend/src/app/(site)/[locale]/privacy/page.tsx
+++ b/frontend/src/app/(site)/[locale]/privacy/page.tsx
@@ -9,6 +9,8 @@ interface LocalePageProps {
   params: Promise<{ locale: string }>;
 }
 
+export const dynamic = "force-static";
+
 export async function generateMetadata({ params }: LocalePageProps): Promise<Metadata> {
   const { locale } = await params;
 

--- a/frontend/src/app/(site)/[locale]/season10-recap/page.tsx
+++ b/frontend/src/app/(site)/[locale]/season10-recap/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
 import { isRouteLocale } from "@/i18n/routing";
 import { localizeMetadata } from "@/lib/routeMetadata";
 import SeasonRecapPage, {
@@ -22,4 +23,14 @@ export async function generateMetadata({ params }: LocalePageProps): Promise<Met
   return localizeMetadata(baseMetadata, "/season10-recap", locale);
 }
 
-export default SeasonRecapPage;
+export default async function LocalizedSeasonRecapPage({ params }: LocalePageProps) {
+  const { locale } = await params;
+
+  if (!isRouteLocale(locale)) {
+    notFound();
+  }
+
+  setRequestLocale(locale);
+
+  return <SeasonRecapPage />;
+}

--- a/frontend/src/app/(site)/[locale]/season10-recap/page.tsx
+++ b/frontend/src/app/(site)/[locale]/season10-recap/page.tsx
@@ -11,6 +11,7 @@ interface LocalePageProps {
   params: Promise<{ locale: string }>;
 }
 
+export const dynamic = "force-static";
 export const revalidate = 3600;
 
 export async function generateMetadata({ params }: LocalePageProps): Promise<Metadata> {

--- a/frontend/src/app/(site)/[locale]/synergy-detail/page.tsx
+++ b/frontend/src/app/(site)/[locale]/synergy-detail/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
 import { isRouteLocale } from "@/i18n/routing";
 import { localizeMetadata } from "@/lib/routeMetadata";
 import SynergyDetailPage, {
@@ -26,4 +27,14 @@ export async function generateMetadata({
   return localizeMetadata(await generateBaseMetadata({ searchParams }), "/synergy-detail", locale);
 }
 
-export default SynergyDetailPage;
+export default async function LocalizedSynergyDetailPage({ params }: LocalePageProps) {
+  const { locale } = await params;
+
+  if (!isRouteLocale(locale)) {
+    notFound();
+  }
+
+  setRequestLocale(locale);
+
+  return <SynergyDetailPage />;
+}

--- a/frontend/src/app/(site)/[locale]/synergy/page.tsx
+++ b/frontend/src/app/(site)/[locale]/synergy/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
 import { isRouteLocale } from "@/i18n/routing";
 import { localizeMetadata } from "@/lib/routeMetadata";
 import SynergyPage, { generateMetadata as generateBaseMetadata } from "@/views/synergy/SynergyPage";
@@ -20,4 +21,14 @@ export async function generateMetadata({ params }: LocalePageProps): Promise<Met
   return localizeMetadata(await generateBaseMetadata(), "/synergy", locale);
 }
 
-export default SynergyPage;
+export default async function LocalizedSynergyPage({ params }: LocalePageProps) {
+  const { locale } = await params;
+
+  if (!isRouteLocale(locale)) {
+    notFound();
+  }
+
+  setRequestLocale(locale);
+
+  return <SynergyPage />;
+}

--- a/frontend/src/app/(site)/[locale]/terms/page.tsx
+++ b/frontend/src/app/(site)/[locale]/terms/page.tsx
@@ -9,6 +9,8 @@ interface LocalePageProps {
   params: Promise<{ locale: string }>;
 }
 
+export const dynamic = "force-static";
+
 export async function generateMetadata({ params }: LocalePageProps): Promise<Metadata> {
   const { locale } = await params;
 

--- a/frontend/src/app/(site)/[locale]/terms/page.tsx
+++ b/frontend/src/app/(site)/[locale]/terms/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
 import { isRouteLocale } from "@/i18n/routing";
 import { localizeMetadata } from "@/lib/routeMetadata";
 import TermsPage, { metadata as baseMetadata } from "@/views/legal/TermsPage";
@@ -18,4 +19,14 @@ export async function generateMetadata({ params }: LocalePageProps): Promise<Met
   return localizeMetadata(baseMetadata, "/terms", locale);
 }
 
-export default TermsPage;
+export default async function LocalizedTermsPage({ params }: LocalePageProps) {
+  const { locale } = await params;
+
+  if (!isRouteLocale(locale)) {
+    notFound();
+  }
+
+  setRequestLocale(locale);
+
+  return <TermsPage />;
+}

--- a/frontend/src/app/(site)/[locale]/updates/page.tsx
+++ b/frontend/src/app/(site)/[locale]/updates/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
 import { isRouteLocale } from "@/i18n/routing";
 import { localizeMetadata } from "@/lib/routeMetadata";
 import UpdatesPage, { metadata as baseMetadata } from "@/views/legal/UpdatesPage";
@@ -18,4 +19,14 @@ export async function generateMetadata({ params }: LocalePageProps): Promise<Met
   return localizeMetadata(baseMetadata, "/updates", locale);
 }
 
-export default UpdatesPage;
+export default async function LocalizedUpdatesPage({ params }: LocalePageProps) {
+  const { locale } = await params;
+
+  if (!isRouteLocale(locale)) {
+    notFound();
+  }
+
+  setRequestLocale(locale);
+
+  return <UpdatesPage />;
+}

--- a/frontend/src/app/(site)/[locale]/updates/page.tsx
+++ b/frontend/src/app/(site)/[locale]/updates/page.tsx
@@ -9,6 +9,8 @@ interface LocalePageProps {
   params: Promise<{ locale: string }>;
 }
 
+export const dynamic = "force-static";
+
 export async function generateMetadata({ params }: LocalePageProps): Promise<Metadata> {
   const { locale } = await params;
 


### PR DESCRIPTION
## 변경 사항
next-intl locale 라우트에서 request 기반 locale 해석으로 인해 일부 페이지가 의도와 다르게 dynamic으로 분류되던 문제를 수정했습니다.

  - locale 라우트 경계에서 `setRequestLocale(locale)`를 호출하도록 정리했습니다.
  - 캐릭터 상세 페이지(`/character/[code]`, `/[locale]/character/[code]`)에 `dynamic = "force-static"`를 적용해 SSG + ISR로 복구했습니다.
  - locale 정적 페이지(`/[locale]/privacy`, `/[locale]/terms`, `/[locale]/updates`, `/[locale]/season10-recap`, `/[locale]/patches/[version]`)에 `dynamic = "force-static"`를 적용했습니다.
  - `/[locale]/patches`, `/[locale]/synergy`, `/[locale]/synergy-detail`도 locale 검증과 `setRequestLocale(locale)`를 타도록 엔트리 구조를 정리했습니다.

## 테스트 결과 (테스트를 했으면)
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.