### PR TITLE
[fix] 조합 추천 검색용 통합 집계 테이블 도입 및 소표본 기준 조정

### DIFF
--- a/frontend/src/app/api/stats/trios-weapon/route.ts
+++ b/frontend/src/app/api/stats/trios-weapon/route.ts
@@ -12,6 +12,7 @@ const DIAMOND_PLUS_TIERS: TierGroup[] = [
   TierGroup.IN1000,
 ];
 const EXCLUDED_CHARACTER_CODES = new Set([9998, 9999]);
+const TRIO_WEAPON_SEARCH_P10_TABLE = "v2_CharacterTrioWeaponSearch_p10";
 
 // .or() 한 번에 character1/2/3 세 컬럼 OR 절을 던지면 인기 캐릭(예: 자히르=1)에서
 // PostgREST statement_timeout(~3s) 초과 → 500. 컬럼당 단일 인덱스만 쓰는 .eq() 3쿼리
@@ -92,6 +93,118 @@ interface AggregatedTrioWeapon {
   winRate: number;
   averageRP: number;
   averageRank: number;
+}
+
+interface TrioWeaponSearchRow {
+  ally1_char: number;
+  ally1_weapon: number;
+  ally1_core: number | null;
+  ally2_char: number;
+  ally2_weapon: number;
+  ally2_core: number | null;
+  third_char: number;
+  third_weapon: number;
+  third_core: number | null;
+  total_games: number;
+  total_wins: number;
+  total_rp: number;
+  rank_sum: number;
+}
+
+function searchRowKey(row: TrioWeaponSearchRow): string {
+  return [
+    row.ally1_char,
+    row.ally1_weapon,
+    row.ally1_core ?? 0,
+    row.ally2_char,
+    row.ally2_weapon,
+    row.ally2_core ?? 0,
+    row.third_char,
+    row.third_weapon,
+    row.third_core ?? 0,
+  ].join("|");
+}
+
+function normalizeSelectedPair(
+  char1: number,
+  weapon1: number | null,
+  char2: number,
+  weapon2: number | null
+) {
+  if (char1 < char2) {
+    return {
+      ally1Char: char1,
+      ally1Weapon: weapon1,
+      ally2Char: char2,
+      ally2Weapon: weapon2,
+    };
+  }
+
+  return {
+    ally1Char: char2,
+    ally1Weapon: weapon2,
+    ally2Char: char1,
+    ally2Weapon: weapon1,
+  };
+}
+
+function mapSearchRowToAggregated(row: TrioWeaponSearchRow): AggregatedTrioWeapon {
+  return {
+    character1: row.ally1_char,
+    weaponType1: row.ally1_weapon,
+    character2: row.ally2_char,
+    weaponType2: row.ally2_weapon,
+    character3: row.third_char,
+    weaponType3: row.third_weapon,
+    mainCore1: row.ally1_core,
+    mainCore2: row.ally2_core,
+    mainCore3: row.third_core,
+    totalGames: row.total_games,
+    winRate: row.total_games > 0 ? (row.total_wins / row.total_games) * 100 : 0,
+    averageRP: row.total_games > 0 ? row.total_rp / row.total_games / 3 : 0,
+    averageRank: row.total_games > 0 ? row.rank_sum / row.total_games : 0,
+  };
+}
+
+function aggregateSearchRows(rows: TrioWeaponSearchRow[]): AggregatedTrioWeapon[] {
+  const grouped = new Map<string, TrioWeaponSearchRow>();
+
+  for (const row of rows) {
+    const key = searchRowKey(row);
+    const existing = grouped.get(key);
+
+    if (!existing) {
+      grouped.set(key, { ...row });
+      continue;
+    }
+
+    existing.total_games += row.total_games;
+    existing.total_wins += row.total_wins;
+    existing.total_rp += row.total_rp;
+    existing.rank_sum += row.rank_sum;
+  }
+
+  return Array.from(grouped.values()).map(mapSearchRowToAggregated);
+}
+
+function sortAggregatedResults(results: AggregatedTrioWeapon[], sortByParam: SortBy) {
+  if (sortByParam === "recommended") {
+    const globalAvgRP =
+      results.length > 0 ? results.reduce((sum, r) => sum + r.averageRP, 0) / results.length : 0;
+    const rpValues = results.map((r) => r.averageRP);
+    const rpRange = { min: Math.min(...rpValues), max: Math.max(...rpValues) };
+    results.sort(
+      (a, b) =>
+        recommendedScore(b, globalAvgRP, rpRange) - recommendedScore(a, globalAvgRP, rpRange)
+    );
+    return;
+  }
+
+  results.sort((a, b) => {
+    if (sortByParam === "averageRP") return b.averageRP - a.averageRP;
+    if (sortByParam === "winRate") return b.winRate - a.winRate;
+    return b.totalGames - a.totalGames;
+  });
 }
 
 function aggregateByTrioWeapon(rows: TrioWeaponRow[]): AggregatedTrioWeapon[] {
@@ -200,6 +313,50 @@ export async function GET(request: NextRequest) {
     const select =
       "tier,character1,weapon_type1,character2,weapon_type2,character3,weapon_type3,main_core1,main_core2,main_core3,total_games,total_wins,total_rp,rank_sum";
 
+    if (char1 != null && char2 != null) {
+      const normalized = normalizeSelectedPair(char1, weapon1, char2, weapon2);
+      let searchQuery = supabase
+        .from(TRIO_WEAPON_SEARCH_P10_TABLE)
+        .select(
+          "ally1_char,ally1_weapon,ally1_core,ally2_char,ally2_weapon,ally2_core,third_char,third_weapon,third_core,total_games,total_wins,total_rp,rank_sum"
+        )
+        .eq("ally1_char", normalized.ally1Char)
+        .eq("ally2_char", normalized.ally2Char)
+        .order("total_games", { ascending: false })
+        .limit(FULL_FETCH_LIMIT);
+
+      if (normalized.ally1Weapon != null) {
+        searchQuery = searchQuery.eq("ally1_weapon", normalized.ally1Weapon);
+      }
+      if (normalized.ally2Weapon != null) {
+        searchQuery = searchQuery.eq("ally2_weapon", normalized.ally2Weapon);
+      }
+
+      const { data: searchRows, error: searchError } = await searchQuery;
+
+      if (searchError) {
+        console.warn(
+          `[stats/trios-weapon] ${TRIO_WEAPON_SEARCH_P10_TABLE} fallback:`,
+          searchError.message
+        );
+      } else {
+        const aggregated = aggregateSearchRows((searchRows ?? []) as TrioWeaponSearchRow[]);
+
+        if (aggregated.length > 0) {
+          sortAggregatedResults(aggregated, sortByParam);
+
+          return NextResponse.json(
+            { results: aggregated.slice(0, limit) },
+            { headers: getCacheHeaders("frequent") }
+          );
+        }
+
+        console.info(
+          `[stats/trios-weapon] ${TRIO_WEAPON_SEARCH_P10_TABLE} returned 0 rows, fallback to v2_CharacterTrioWeapon`
+        );
+      }
+    }
+
     const baseQuery = (perQueryLimit: number) =>
       supabase
         .from("v2_CharacterTrioWeapon")
@@ -297,25 +454,7 @@ export async function GET(request: NextRequest) {
     });
 
     const aggregated = aggregateByTrioWeapon(filteredRows);
-
-    if (sortByParam === "recommended") {
-      const globalAvgRP =
-        aggregated.length > 0
-          ? aggregated.reduce((sum, r) => sum + r.averageRP, 0) / aggregated.length
-          : 0;
-      const rpValues = aggregated.map((r) => r.averageRP);
-      const rpRange = { min: Math.min(...rpValues), max: Math.max(...rpValues) };
-      aggregated.sort(
-        (a, b) =>
-          recommendedScore(b, globalAvgRP, rpRange) - recommendedScore(a, globalAvgRP, rpRange)
-      );
-    } else {
-      aggregated.sort((a, b) => {
-        if (sortByParam === "averageRP") return b.averageRP - a.averageRP;
-        if (sortByParam === "winRate") return b.winRate - a.winRate;
-        return b.totalGames - a.totalGames;
-      });
-    }
+    sortAggregatedResults(aggregated, sortByParam);
 
     return NextResponse.json(
       { results: aggregated.slice(0, limit) },

--- a/frontend/src/components/features/synergy-detail/ComboWeaponCard.tsx
+++ b/frontend/src/components/features/synergy-detail/ComboWeaponCard.tsx
@@ -11,6 +11,8 @@ import { TraitIcon } from "./TraitIcon";
 import type { TrioWeaponResult } from "./types";
 import { useTapGuard } from "./useTapGuard";
 
+const SMALL_SAMPLE_THRESHOLD = 20;
+
 /** Level 1 (접힘): 캐릭터+무기 조합 (mainCore 집계) */
 export interface GroupedCombo {
   character1: number;
@@ -89,7 +91,7 @@ function ComboWeaponCardImpl({
     () => getOrderedMembers(group, selectedCharCodes),
     [group, selectedCharCodes]
   );
-  const isSmallSample = group.totalGames <= 10;
+  const isSmallSample = group.totalGames < SMALL_SAMPLE_THRESHOLD;
   // 상위 10개까지 잘라두고, 초기 펼침에서는 상위 3개만 노출하여 첫 커밋 비용을 줄임.
   // 나머지는 "더보기" 로 유저 의도 있을 때만 mount (TraitIcon n×3 서브트리가 무거워서 INP 주요 기여자).
   const sortedVariants = React.useMemo(

--- a/frontend/src/components/features/synergy-detail/SynergyDetailResults.tsx
+++ b/frontend/src/components/features/synergy-detail/SynergyDetailResults.tsx
@@ -140,6 +140,7 @@ export function SynergyDetailResults() {
   const [results, setResults] = React.useState<TrioWeaponResult[]>([]);
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
+  const MIN_MEANINGFUL_GAMES = 20;
 
   /**
    * 1번 탭 즉각 반응 핵심:
@@ -311,8 +312,8 @@ export function SynergyDetailResults() {
     if (sortBy === "recommended") {
       grouped.sort((a, b) => {
         // 소표본 후순위
-        const aOk = a.totalGames > 10 && a.averageRP >= 0;
-        const bOk = b.totalGames > 10 && b.averageRP >= 0;
+        const aOk = a.totalGames >= MIN_MEANINGFUL_GAMES && a.averageRP >= 0;
+        const bOk = b.totalGames >= MIN_MEANINGFUL_GAMES && b.averageRP >= 0;
         if (aOk !== bOk) return aOk ? -1 : 1;
         return b.averageRP - a.averageRP;
       });
@@ -325,7 +326,7 @@ export function SynergyDetailResults() {
     }
 
     return grouped;
-  }, [results, deferredAllies, deferredCharCodes, focusCharWeapons, sortBy]);
+  }, [results, deferredAllies, deferredCharCodes, focusCharWeapons, sortBy, MIN_MEANINGFUL_GAMES]);
 
   const clearAllies = React.useCallback(() => {
     router.replace(pathname, { scroll: false });

--- a/frontend/src/components/features/synergy/ComboCard.tsx
+++ b/frontend/src/components/features/synergy/ComboCard.tsx
@@ -1,10 +1,12 @@
-"use client"
+"use client";
 
-import Image from "next/image"
-import * as React from "react"
-import { getCharacterMiniWebpUrl } from "@/lib/characterMap"
-import { cn } from "@/lib/utils"
-import type { TrioResult } from "./types"
+import Image from "next/image";
+import * as React from "react";
+import { getCharacterMiniWebpUrl } from "@/lib/characterMap";
+import { cn } from "@/lib/utils";
+import type { TrioResult } from "./types";
+
+const SMALL_SAMPLE_THRESHOLD = 20;
 
 export function ComboCard({
   rec,
@@ -15,30 +17,30 @@ export function ComboCard({
   priorityImages = false,
   onNavigateAnalysis,
 }: {
-  rec: TrioResult
-  rank: number
-  getCharName: (code: number) => string
-  selectedAllies: number[]
-  compact?: boolean
+  rec: TrioResult;
+  rank: number;
+  getCharName: (code: number) => string;
+  selectedAllies: number[];
+  compact?: boolean;
   /** true면 이미지를 priority로 즉시 로드 (상위 카드용) */
-  priorityImages?: boolean
-  onNavigateAnalysis?: (code: number) => void
+  priorityImages?: boolean;
+  onNavigateAnalysis?: (code: number) => void;
 }) {
   // 선택한 아군을 앞에, 추천 캐릭터를 마지막에 표시
-  const allChars = [rec.character1, rec.character2, rec.character3]
-  const allies: number[] = []
-  const rest: number[] = []
+  const allChars = [rec.character1, rec.character2, rec.character3];
+  const allies: number[] = [];
+  const rest: number[] = [];
   for (const code of allChars) {
     if (selectedAllies.includes(code) && allies.length < selectedAllies.length) {
-      allies.push(code)
+      allies.push(code);
     } else {
-      rest.push(code)
+      rest.push(code);
     }
   }
   // 선택 순서 유지
-  allies.sort((a, b) => selectedAllies.indexOf(a) - selectedAllies.indexOf(b))
-  const chars = [...allies, ...rest]
-  const isSmallSample = rec.totalGames <= 10
+  allies.sort((a, b) => selectedAllies.indexOf(a) - selectedAllies.indexOf(b));
+  const chars = [...allies, ...rest];
+  const isSmallSample = rec.totalGames < SMALL_SAMPLE_THRESHOLD;
 
   return (
     <div className="group flex items-center gap-2 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)]/80 px-3 py-2.5 hover:bg-[var(--color-primary)]/[0.04] hover:border-[var(--color-primary)]/20 transition-all duration-200">
@@ -50,7 +52,7 @@ export function ComboCard({
       {/* 3캐릭터 */}
       <div className="flex items-center gap-1">
         {chars.map((code, i) => {
-          const isRecommended = !selectedAllies.includes(code)
+          const isRecommended = !selectedAllies.includes(code);
           const charContent = (
             <div className="flex flex-col items-center gap-0.5">
               <div
@@ -71,17 +73,19 @@ export function ComboCard({
                 />
               </div>
               {!compact && (
-                <span className={cn(
-                  "w-10 truncate text-center text-[9px]",
-                  isRecommended
-                    ? "text-[var(--color-accent-gold)] group-hover/char:text-[var(--color-primary)]"
-                    : "text-[var(--color-muted-foreground)]"
-                )}>
+                <span
+                  className={cn(
+                    "w-10 truncate text-center text-[9px]",
+                    isRecommended
+                      ? "text-[var(--color-accent-gold)] group-hover/char:text-[var(--color-primary)]"
+                      : "text-[var(--color-muted-foreground)]"
+                  )}
+                >
                   {getCharName(code)}
                 </span>
               )}
             </div>
-          )
+          );
           return (
             <React.Fragment key={code}>
               {isRecommended && onNavigateAnalysis ? (
@@ -101,11 +105,9 @@ export function ComboCard({
               ) : (
                 charContent
               )}
-              {i < 2 && (
-                <span className="text-[10px] text-[var(--color-border)]">+</span>
-              )}
+              {i < 2 && <span className="text-[10px] text-[var(--color-border)]">+</span>}
             </React.Fragment>
-          )
+          );
         })}
       </div>
 
@@ -122,11 +124,16 @@ export function ComboCard({
           <span className="text-xs font-semibold text-[var(--color-foreground)]">
             {rec.winRate.toFixed(1)}%
           </span>
-          <span className={cn(
-            "text-[10px]",
-            rec.averageRP >= 0 ? "text-[var(--color-accent-gold)]" : "text-[var(--color-muted-foreground)]"
-          )}>
-            {rec.averageRP > 0 ? "+" : ""}{rec.averageRP.toFixed(1)} RP
+          <span
+            className={cn(
+              "text-[10px]",
+              rec.averageRP >= 0
+                ? "text-[var(--color-accent-gold)]"
+                : "text-[var(--color-muted-foreground)]"
+            )}
+          >
+            {rec.averageRP > 0 ? "+" : ""}
+            {rec.averageRP.toFixed(1)} RP
           </span>
         </div>
       ) : (
@@ -139,11 +146,16 @@ export function ComboCard({
           </div>
           <div className="flex flex-col">
             <span className="text-[10px] text-[var(--color-muted-foreground)]">평균 RP</span>
-            <span className={cn(
-              "text-sm font-semibold",
-              rec.averageRP >= 0 ? "text-[var(--color-accent-gold)]" : "text-[var(--color-muted-foreground)]"
-            )}>
-              {rec.averageRP > 0 ? "+" : ""}{rec.averageRP.toFixed(1)}
+            <span
+              className={cn(
+                "text-sm font-semibold",
+                rec.averageRP >= 0
+                  ? "text-[var(--color-accent-gold)]"
+                  : "text-[var(--color-muted-foreground)]"
+              )}
+            >
+              {rec.averageRP > 0 ? "+" : ""}
+              {rec.averageRP.toFixed(1)}
             </span>
           </div>
           <div className="flex flex-col">
@@ -160,7 +172,6 @@ export function ComboCard({
           </div>
         </div>
       )}
-
     </div>
-  )
+  );
 }

--- a/frontend/src/components/features/synergy/SynergyResults.tsx
+++ b/frontend/src/components/features/synergy/SynergyResults.tsx
@@ -51,6 +51,7 @@ export function SynergyResults({ compact = false }: { compact?: boolean }) {
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
   const [copied, setCopied] = React.useState(false);
+  const MIN_MEANINGFUL_GAMES = 20;
 
   const getCharName = React.useCallback(
     (code: number) => resolveCharacterName(code, l10n, getFallbackMap()),
@@ -127,13 +128,13 @@ export function SynergyResults({ compact = false }: { compact?: boolean }) {
     const sorted =
       sortBy === "recommended"
         ? [
-            ...deduped.filter((r) => r.totalGames > 10 && r.averageRP >= 0),
-            ...deduped.filter((r) => r.totalGames > 10 && r.averageRP < 0),
-            ...deduped.filter((r) => r.totalGames <= 10),
+            ...deduped.filter((r) => r.totalGames >= MIN_MEANINGFUL_GAMES && r.averageRP >= 0),
+            ...deduped.filter((r) => r.totalGames >= MIN_MEANINGFUL_GAMES && r.averageRP < 0),
+            ...deduped.filter((r) => r.totalGames < MIN_MEANINGFUL_GAMES),
           ]
         : [...deduped.filter((r) => r.averageRP >= 0), ...deduped.filter((r) => r.averageRP < 0)];
     return sorted.slice(0, 20);
-  }, [trioResults, selectedAllies, focusCharacters, sortBy]);
+  }, [trioResults, selectedAllies, focusCharacters, sortBy, MIN_MEANINGFUL_GAMES]);
 
   const clearAllies = React.useCallback(() => {
     router.replace(withCurrentRouteLocale(pathname, "/synergy-detail"), { scroll: false });


### PR DESCRIPTION
## 변경 사항
- `/api/stats/trios-weapon`가 통합 집계 테이블(`v2_CharacterTrioWeaponSearch_p10`)을 우선 조회하고, 테이블이 비어 있거나 에러가 나면 기존 `v2_CharacterTrioWeapon` 경로로 fallback 하도록 변경했습니다.
- 조합 추천 UI의 소표본 기준을 `10판`에서 `20판`으로 상향했습니다.
- 일반 조합 추천, 무기 포함 조합 추천, 카드의 `소표본` 배지 기준을 동일하게 `20판 미만`으로 맞췄습니다

## 테스트 결과 (테스트를 했으면)
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.