### PR TITLE
[fix] ISR Write 비용 폭증 및 revalidate 재설계

### DIFF
--- a/frontend/src/app/(default)/character/[code]/page.tsx
+++ b/frontend/src/app/(default)/character/[code]/page.tsx
@@ -4,15 +4,12 @@ import { CharacterPageContent } from "@/components/features/character-analysis/C
 import { CHARACTER_CODES } from "@/components/features/character-analysis/constants";
 import { getAllPatchVersions } from "@/data/patch-notes";
 import { buildFallbackMap, resolveCharacterName } from "@/lib/characterMap";
-import { getCachedCharacterStats } from "@/lib/characterStats";
 import { DEFAULT_LANGUAGE } from "@/lib/detectLanguage";
 import { buildDefaultAlternates } from "@/lib/seoLocales";
 import { loadL10nMap } from "@/lib/serverL10n";
 import { BASE_URL } from "@/lib/siteMetadata";
 import { getStaticTranslator, OG_LOCALE_BY_LANGUAGE } from "@/lib/staticIntl";
-import { TierGroup } from "@/utils/tier";
 
-export const revalidate = 3600;
 export const dynamic = "force-static";
 export const dynamicParams = false;
 
@@ -113,18 +110,14 @@ export default async function DefaultCharacterPage({ params }: Props) {
     latestPinnedPatch,
     ...getAllPatchVersions().filter((patch) => patch !== latestPinnedPatch),
   ];
-  const [initialStats, initialPrevStats] = await Promise.all([
-    patches[0] ? getCachedCharacterStats(code, patches[0], TierGroup.DIAMOND) : null,
-    patches[1] ? getCachedCharacterStats(code, patches[1], TierGroup.DIAMOND) : null,
-  ]);
 
   return (
     <CharacterPageContent
       locale="ko"
       code={code}
       patches={patches}
-      initialStats={initialStats}
-      initialPrevStats={initialPrevStats}
+      initialStats={null}
+      initialPrevStats={null}
     />
   );
 }

--- a/frontend/src/app/(site)/[locale]/character/[code]/page.tsx
+++ b/frontend/src/app/(site)/[locale]/character/[code]/page.tsx
@@ -6,14 +6,11 @@ import { CHARACTER_CODES } from "@/components/features/character-analysis/consta
 import { getAllPatchVersions } from "@/data/patch-notes";
 import { LANGUAGE_BY_ROUTE_LOCALE, ROUTE_LOCALES, isRouteLocale } from "@/i18n/routing";
 import { buildFallbackMap, resolveCharacterName } from "@/lib/characterMap";
-import { getCachedCharacterStats } from "@/lib/characterStats";
 import { buildLocalizedAlternates, localizeRoutePath } from "@/lib/seoLocales";
 import { loadL10nMap } from "@/lib/serverL10n";
 import { BASE_URL } from "@/lib/siteMetadata";
 import { getStaticTranslator, OG_LOCALE_BY_LANGUAGE } from "@/lib/staticIntl";
-import { TierGroup } from "@/utils/tier";
 
-export const revalidate = 3600;
 export const dynamic = "force-static";
 export const dynamicParams = false;
 
@@ -128,18 +125,14 @@ export default async function LocalizedCharacterPage({ params }: Props) {
     latestPinnedPatch,
     ...getAllPatchVersions().filter((patch) => patch !== latestPinnedPatch),
   ];
-  const [initialStats, initialPrevStats] = await Promise.all([
-    patches[0] ? getCachedCharacterStats(code, patches[0], TierGroup.DIAMOND) : null,
-    patches[1] ? getCachedCharacterStats(code, patches[1], TierGroup.DIAMOND) : null,
-  ]);
 
   return (
     <CharacterPageContent
       locale={locale}
       code={code}
       patches={patches}
-      initialStats={initialStats}
-      initialPrevStats={initialPrevStats}
+      initialStats={null}
+      initialPrevStats={null}
     />
   );
 }

--- a/frontend/src/app/(site)/[locale]/page.tsx
+++ b/frontend/src/app/(site)/[locale]/page.tsx
@@ -4,8 +4,8 @@ import { setRequestLocale } from "next-intl/server";
 import { HomePageContent } from "@/components/features/home/HomePageContent";
 import { LANGUAGE_BY_ROUTE_LOCALE, ROUTE_LOCALES, isRouteLocale } from "@/i18n/routing";
 import { getPatches } from "@/lib/getPatches";
-import { fetchHoneyPicksServer } from "@/lib/honeyPicks";
-import { fetchRankingData } from "@/lib/ranking";
+import { getCachedHoneyPicks } from "@/lib/honeyPicks";
+import { getCachedRankingData } from "@/lib/ranking";
 import { buildLocalizedAlternates, localizeRoutePath } from "@/lib/seoLocales";
 import { BASE_URL } from "@/lib/siteMetadata";
 import { getMessage, loadIntlMessages, OG_LOCALE_BY_LANGUAGE } from "@/lib/staticIntl";
@@ -75,7 +75,7 @@ export default async function LocalizedHomePage({ params }: LocalePageProps) {
   setRequestLocale(locale);
 
   const defaultTier = "DIAMOND";
-  const emptyRankingData: Awaited<ReturnType<typeof fetchRankingData>> = {
+  const emptyRankingData: Awaited<ReturnType<typeof getCachedRankingData>> = {
     rankings: [],
     previousRankings: [],
     patchVersion: "",
@@ -86,7 +86,7 @@ export default async function LocalizedHomePage({ params }: LocalePageProps) {
   const patches = await getPatches();
   const defaultPatch = patches[0] ?? "";
 
-  let honeyData: Awaited<ReturnType<typeof fetchHoneyPicksServer>> = {
+  let honeyData: Awaited<ReturnType<typeof getCachedHoneyPicks>> = {
     picks: [],
     patchVersion: "",
     previousPatch: null as string | null,
@@ -97,8 +97,8 @@ export default async function LocalizedHomePage({ params }: LocalePageProps) {
   if (defaultPatch) {
     try {
       [honeyData, rankingData] = await Promise.all([
-        fetchHoneyPicksServer(defaultPatch, defaultTier),
-        fetchRankingData(defaultPatch, defaultTier),
+        getCachedHoneyPicks(defaultPatch, defaultTier),
+        getCachedRankingData(defaultPatch, defaultTier),
       ]);
     } catch {
       honeyData = { ...honeyData, patchVersion: defaultPatch };

--- a/frontend/src/app/(site)/[locale]/patches/[version]/page.tsx
+++ b/frontend/src/app/(site)/[locale]/patches/[version]/page.tsx
@@ -14,7 +14,6 @@ interface LocalePageProps {
 
 export const dynamic = "force-static";
 export const dynamicParams = false;
-export const revalidate = 3600;
 
 export function generateStaticParams() {
   return generateBaseStaticParams().flatMap(({ version }) =>

--- a/frontend/src/app/(site)/[locale]/season10-recap/page.tsx
+++ b/frontend/src/app/(site)/[locale]/season10-recap/page.tsx
@@ -12,7 +12,7 @@ interface LocalePageProps {
 }
 
 export const dynamic = "force-static";
-export const revalidate = 3600;
+export const revalidate = 86400;
 
 export async function generateMetadata({ params }: LocalePageProps): Promise<Metadata> {
   const { locale } = await params;

--- a/frontend/src/app/(site)/[locale]/synergy/page.tsx
+++ b/frontend/src/app/(site)/[locale]/synergy/page.tsx
@@ -9,8 +9,6 @@ interface LocalePageProps {
   params: Promise<{ locale: string }>;
 }
 
-export const revalidate = 300;
-
 export async function generateMetadata({ params }: LocalePageProps): Promise<Metadata> {
   const { locale } = await params;
 

--- a/frontend/src/app/api/character/mithril-rp-ranking/route.ts
+++ b/frontend/src/app/api/character/mithril-rp-ranking/route.ts
@@ -1,11 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCacheHeaders, NO_CACHE_HEADERS } from "@/lib/cache";
 import { getPatches } from "@/lib/getPatches";
-import { fetchRankingData } from "@/lib/ranking";
+import { getCachedRankingData } from "@/lib/ranking";
 
 export type { CharacterRankingData } from "@/lib/ranking";
-
-export const revalidate = 1800; // L1: 30분 서버 캐시
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
@@ -27,7 +25,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const result = await fetchRankingData(patchVersion, requestedTier);
+    const result = await getCachedRankingData(patchVersion, requestedTier);
 
     return NextResponse.json(result, { headers: getCacheHeaders("daily") });
   } catch (err) {

--- a/frontend/src/app/api/character/stats/[characterCode]/route.ts
+++ b/frontend/src/app/api/character/stats/[characterCode]/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCacheHeaders, NO_CACHE_HEADERS } from "@/lib/cache";
-import { fetchCharacterStatsServer, type CharacterStatsResponse } from "@/lib/characterStats";
+import { getCachedCharacterStats, type CharacterStatsResponse } from "@/lib/characterStats";
 
-export const revalidate = 1800; // L1: 30분 서버 캐시
 export type { CharacterStatsResponse, WeaponStatItem } from "@/lib/characterStats";
 
 export async function GET(
@@ -21,7 +20,10 @@ export async function GET(
   const patchVersion = searchParams.get("patchVersion") ?? "11.1";
 
   try {
-    const stats = await fetchCharacterStatsServer(characterCode, patchVersion, tier);
+    const stats = await getCachedCharacterStats(characterCode, patchVersion, tier);
+    if (!stats) {
+      throw new Error("Failed to load cached character stats");
+    }
     return NextResponse.json(stats satisfies CharacterStatsResponse, {
       headers: getCacheHeaders("daily"),
     });

--- a/frontend/src/components/features/character-analysis/CharacterAnalysisClient.tsx
+++ b/frontend/src/components/features/character-analysis/CharacterAnalysisClient.tsx
@@ -132,8 +132,9 @@ export function CharacterAnalysisClient({
 
   // 티어 변경 시 데이터 리페치
   React.useEffect(() => {
-    if (selectedTier === TierGroup.MITHRIL) {
-      // 서버에서 받은 초기 데이터로 복원
+    let cancelled = false;
+
+    if (selectedTier === TierGroup.DIAMOND && initialStats) {
       setStats(initialStats ?? null);
       setPreviousStats(initialPrevStats ?? null);
       setAllPatchStats(() => {
@@ -143,34 +144,52 @@ export function CharacterAnalysisClient({
         return initial;
       });
       setSelectedWeapon(readWeaponFromLocation() ?? initialStats?.weapons?.[0]?.bestWeapon ?? null);
-      return;
+      setLoading(false);
+      return () => {
+        cancelled = true;
+      };
     }
 
-    setLoading(true);
-    setStats(null);
-    setPreviousStats(null);
-    setAllPatchStats([]);
-    setSelectedWeapon(null);
+    const fetchPriorityStats = async () => {
+      setLoading(true);
+      setStats(null);
+      setPreviousStats(null);
+      setAllPatchStats([]);
+      setSelectedWeapon(null);
 
-    const priorityPatches = patches.slice(0, 2);
-    Promise.all(priorityPatches.map((p) => fetchStats(code, p, selectedTier))).then(
-      (priorityResults) => {
-        const current = priorityResults[0] ?? null;
-        setStats(current);
-        setPreviousStats(priorityResults[1] ?? null);
-        if (current?.weapons && current.weapons.length > 0) {
-          setSelectedWeapon(current.weapons[0].bestWeapon ?? null);
-        }
-        const initial: (CharacterStatsResponse | null)[] = Array(patches.length).fill(null);
-        priorityResults.forEach((r, i) => {
-          initial[i] = r;
-        });
-        setAllPatchStats(initial);
-        setLoading(false);
+      const priorityPatches = patches.slice(0, 2);
+      const priorityResults = await Promise.all(
+        priorityPatches.map((patch) => fetchStats(code, patch, selectedTier))
+      );
+
+      if (cancelled) {
+        return;
       }
-    );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedTier]);
+
+      const current = priorityResults[0] ?? null;
+      setStats(current);
+      setPreviousStats(priorityResults[1] ?? null);
+      setSelectedWeapon(readWeaponFromLocation() ?? current?.weapons?.[0]?.bestWeapon ?? null);
+
+      const initial: (CharacterStatsResponse | null)[] = Array(patches.length).fill(null);
+      priorityResults.forEach((result, index) => {
+        initial[index] = result;
+      });
+      setAllPatchStats(initial);
+      setLoading(false);
+    };
+
+    void fetchPriorityStats().catch(() => {
+      if (cancelled) {
+        return;
+      }
+      setLoading(false);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [code, initialPrevStats, initialStats, patches, selectedTier]);
 
   const currentPatch = patches[0] ?? null;
 

--- a/frontend/src/lib/characterStats.ts
+++ b/frontend/src/lib/characterStats.ts
@@ -54,12 +54,10 @@ function buildEmptyResponse(
   };
 }
 
-export async function fetchCharacterStatsServer(
-  characterCode: number,
+async function fetchCharacterStatRowsServer(
   patchVersion: string,
   tier: string
-): Promise<CharacterStatsResponse> {
-  const emptyResponse = buildEmptyResponse(characterCode, patchVersion, tier);
+): Promise<StatRow[]> {
   const supabase = createServerClient();
 
   const selectCols = "characterNum,bestWeapon,totalGames,totalWins,totalRP,totalTop3,averageRank";
@@ -80,10 +78,24 @@ export async function fetchCharacterStatsServer(
   }
 
   if (error || !data || data.length === 0) {
+    return [];
+  }
+
+  return data as StatRow[];
+}
+
+function buildCharacterStatsResponse(
+  allRows: StatRow[],
+  characterCode: number,
+  patchVersion: string,
+  tier: string
+): CharacterStatsResponse {
+  const emptyResponse = buildEmptyResponse(characterCode, patchVersion, tier);
+
+  if (allRows.length === 0) {
     return emptyResponse;
   }
 
-  const allRows = data as StatRow[];
   const grandTotal = allRows.reduce((sum, row) => sum + (row.totalGames ?? 0), 0);
   const rows = allRows.filter((row) => row.characterNum === characterCode);
 
@@ -127,24 +139,38 @@ export async function fetchCharacterStatsServer(
   };
 }
 
+export async function fetchCharacterStatsServer(
+  characterCode: number,
+  patchVersion: string,
+  tier: string
+): Promise<CharacterStatsResponse> {
+  const allRows = await fetchCharacterStatRowsServer(patchVersion, tier);
+  return buildCharacterStatsResponse(allRows, characterCode, patchVersion, tier);
+}
+
+async function getCachedCharacterStatRows(patchVersion: string, tier: string): Promise<StatRow[]> {
+  return unstable_cache(
+    async () => fetchCharacterStatRowsServer(patchVersion, tier),
+    ["character-stats-rows", patchVersion, tier],
+    {
+      revalidate: 3600,
+      tags: [
+        "character-stats:rows",
+        `character-stats:patch:${patchVersion}`,
+        `character-stats:tier:${tier}`,
+      ],
+    }
+  )();
+}
+
 export async function getCachedCharacterStats(
   characterCode: number,
   patchVersion: string,
   tier: string
 ): Promise<CharacterStatsResponse | null> {
   try {
-    return await unstable_cache(
-      async () => fetchCharacterStatsServer(characterCode, patchVersion, tier),
-      ["character-stats", String(characterCode), patchVersion, tier],
-      {
-        revalidate: 3600,
-        tags: [
-          `character-stats:${characterCode}`,
-          `character-stats:${characterCode}:${patchVersion}`,
-          `character-stats:tier:${tier}`,
-        ],
-      }
-    )();
+    const allRows = await getCachedCharacterStatRows(patchVersion, tier);
+    return buildCharacterStatsResponse(allRows, characterCode, patchVersion, tier);
   } catch {
     return null;
   }

--- a/frontend/src/lib/honeyPicks.ts
+++ b/frontend/src/lib/honeyPicks.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from "next/cache";
 import type { HoneyPickData } from "@/app/api/meta/honey-picks/route";
 import { createServerClient } from "@/lib/supabase";
 
@@ -102,11 +103,13 @@ export async function fetchHoneyPicksServer(
     // 현재 + 이전 패치 데이터 조회 (v2 → old fallback)
     const selectCols =
       "characterNum,bestWeapon,totalGames,totalWins,totalRP,totalTop3,tier,patchVersion";
-    let { data, error } = await supabase
+    const queryResult = await supabase
       .from("v2_CharacterStats")
       .select(selectCols)
       .in("patchVersion", [patchVersion, previousPatch])
       .in("tier", TIER_FALLBACK_ORDER);
+    const { error } = queryResult;
+    let { data } = queryResult;
 
     // v2에 이전 패치 데이터 없으면 old 테이블 fallback
     if (data && previousPatch) {
@@ -181,4 +184,18 @@ export async function fetchHoneyPicksServer(
     console.error("[honeyPicks] 서버 fetch 예외:", err);
     return empty;
   }
+}
+
+export async function getCachedHoneyPicks(
+  patchVersion: string,
+  requestedTier: string
+): Promise<HoneyPicksResult> {
+  return unstable_cache(
+    async () => fetchHoneyPicksServer(patchVersion, requestedTier),
+    ["honey-picks", patchVersion, requestedTier],
+    {
+      revalidate: 1800,
+      tags: ["honey-picks", `honey-picks:${patchVersion}`, `honey-picks:tier:${requestedTier}`],
+    }
+  )();
 }

--- a/frontend/src/lib/ranking.ts
+++ b/frontend/src/lib/ranking.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from "next/cache";
 import { createServerClient } from "@/lib/supabase";
 
 const TIER_FALLBACK_ORDER = ["DIAMOND", "METEORITE", "MITHRIL", "IN1000"];
@@ -85,11 +86,13 @@ export async function fetchRankingData(
 
   const selectCols =
     "characterNum,bestWeapon,totalGames,totalWins,totalRP,totalTop3,averageRank,tier,patchVersion";
-  let { data, error } = await supabase
+  const queryResult = await supabase
     .from("v2_CharacterStats")
     .select(selectCols)
     .in("patchVersion", patchVersions)
     .in("tier", TIER_FALLBACK_ORDER);
+  const { error } = queryResult;
+  let { data } = queryResult;
 
   // v2에 이전 패치 데이터 없으면 old 테이블 fallback 병합
   if (previousPatch && data) {
@@ -133,4 +136,22 @@ export async function fetchRankingData(
     previousPatch,
     tier: usedTier,
   };
+}
+
+export async function getCachedRankingData(
+  patchVersion: string,
+  requestedTier: string
+): Promise<RankingResponse> {
+  return unstable_cache(
+    async () => fetchRankingData(patchVersion, requestedTier),
+    ["character-rankings", patchVersion, requestedTier],
+    {
+      revalidate: 1800,
+      tags: [
+        "character-rankings",
+        `character-rankings:${patchVersion}`,
+        `character-rankings:tier:${requestedTier}`,
+      ],
+    }
+  )();
 }

--- a/frontend/src/views/patches/PatchDetailPage.tsx
+++ b/frontend/src/views/patches/PatchDetailPage.tsx
@@ -9,7 +9,6 @@ import { Link } from "@/i18n/navigation";
 import { getCharacterMiniWebpUrl, getCharacterName } from "@/lib/characterMap";
 import { getStaticTranslator } from "@/lib/staticIntl";
 
-export const revalidate = 3600;
 export const dynamicParams = false;
 
 function DetailMetricCard({

--- a/frontend/src/views/season10-recap/Season10RecapPage.tsx
+++ b/frontend/src/views/season10-recap/Season10RecapPage.tsx
@@ -29,7 +29,7 @@ export const metadata: Metadata = {
   },
 };
 
-export const revalidate = 3600;
+export const revalidate = 86400;
 
 function formatMetricNumber(value: number) {
   if (!Number.isFinite(value) || value <= 0) return "0";

--- a/frontend/src/views/synergy/SynergyPage.tsx
+++ b/frontend/src/views/synergy/SynergyPage.tsx
@@ -4,8 +4,6 @@ import { getTranslations } from "next-intl/server";
 import { SynergyClient } from "@/components/features/SynergyClient";
 import { Link } from "@/i18n/navigation";
 
-export const revalidate = 300;
-
 export async function generateMetadata(): Promise<Metadata> {
   const tNav = await getTranslations("navigation");
   const tPage = await getTranslations("synergyPage");


### PR DESCRIPTION
## 문제 상황
1. **i18n 도입 (2026-04-30)** — 모든 페이지가 5 locale variant로 복제, unique URL 5배 곱셈
2. **Route-level `revalidate`의 URL 기반 캐시 키** — `[characterCode]` 같은 path param마다 별도 ISR 엔트리 생성. 같은 patch+tier 데이터가 87개 캐릭별로 87번 캐시됨

## 변경 사항
1. refactor: 페이지/뷰 force-static 전환으로 ISR write 제거
2. refactor: characterStats unstable_cache 도입으로 캐시 키 cardinality 축소
3. refactor: ranking unstable_cache 도입으로 캐시 키 cardinality 축소
4. refactor: honeyPicks unstable_cache 도입으로 캐시 키 cardinality 축소

## 테스트 결과 (테스트를 했으면)
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.