### PR TITLE
[fix] 캐시 정책 고도화

### DIFF
--- a/frontend/src/app/(site)/[locale]/trio-lab/page.tsx
+++ b/frontend/src/app/(site)/[locale]/trio-lab/page.tsx
@@ -26,9 +26,7 @@ interface LocalePageProps {
 async function fetchInitialCombos(searchParams: Awaited<SearchParams>) {
   const state = parseTrioLabUrlState(searchParams);
   const rowGroups = await Promise.all(
-    buildTrioWeaponSearchRequests(state.pool, state.sort).map((params) =>
-      fetchTrioWeaponRows(params)
-    )
+    buildTrioWeaponSearchRequests(state.pool).map((params) => fetchTrioWeaponRows(params))
   );
   const rows = rowGroups.flat();
   return sortTrioWeaponCombos(

--- a/frontend/src/app/api/character/stats/[characterCode]/route.ts
+++ b/frontend/src/app/api/character/stats/[characterCode]/route.ts
@@ -28,7 +28,7 @@ export async function GET(
       throw new Error("Failed to load cached character stats");
     }
     return NextResponse.json(stats satisfies CharacterStatsResponse, {
-      headers: withCacheObservability(getCacheHeaders("daily"), latencyMs),
+      headers: withCacheObservability(getCacheHeaders("character-stats"), latencyMs),
     });
   } catch (err) {
     console.error("[character/stats] 예외:", err);

--- a/frontend/src/components/features/synergy-detail/SynergyDetailResults.tsx
+++ b/frontend/src/components/features/synergy-detail/SynergyDetailResults.tsx
@@ -94,6 +94,10 @@ function groupByCharWeapon(results: TrioWeaponResult[]): GroupedCombo[] {
   }));
 }
 
+function sortAllyPair<T extends { charCode: number }>(allies: T[]): T[] {
+  return [...allies].sort((a, b) => a.charCode - b.charCode);
+}
+
 export function SynergyDetailResults() {
   const { l10n } = useL10n();
   const t = useTranslations("synergyResults");
@@ -205,12 +209,13 @@ export function SynergyDetailResults() {
     const controller = new AbortController();
     const timerId = setTimeout(() => {
       const params = new URLSearchParams({ sortBy: "totalGames", limit: "5000" });
-      const a1 = deferredAllies[0];
+      const queryAllies = sortAllyPair(deferredAllies);
+      const a1 = queryAllies[0];
       if (a1) {
         params.set("character1", String(a1.charCode));
         if (a1.weaponCode) params.set("weapon1", String(a1.weaponCode));
       }
-      const a2 = deferredAllies[1];
+      const a2 = queryAllies[1];
       if (a2) {
         params.set("character2", String(a2.charCode));
         if (a2.weaponCode) params.set("weapon2", String(a2.weaponCode));

--- a/frontend/src/components/features/synergy-detail/SynergyDetailResults.tsx
+++ b/frontend/src/components/features/synergy-detail/SynergyDetailResults.tsx
@@ -194,7 +194,7 @@ export function SynergyDetailResults() {
   const getWeaponName = React.useCallback((code: number) => resolveWeaponName(code, l10n), [l10n]);
   const getTraitName = React.useCallback((code: number) => traitNames[code] ?? null, [traitNames]);
 
-  // API 호출 — deferredAllies 기반 (아군 선택 탭 즉시성 확보)
+  // API 호출 — deferredAllies 기반 (아군 선택 탭 즉시성 확보). 정렬은 클라이언트에서 처리해 CDN 키를 줄인다.
   React.useEffect(() => {
     if (deferredAllies.length === 0) {
       setResults([]);
@@ -204,7 +204,7 @@ export function SynergyDetailResults() {
 
     const controller = new AbortController();
     const timerId = setTimeout(() => {
-      const params = new URLSearchParams({ sortBy, limit: "5000" });
+      const params = new URLSearchParams({ sortBy: "totalGames", limit: "5000" });
       const a1 = deferredAllies[0];
       if (a1) {
         params.set("character1", String(a1.charCode));
@@ -258,7 +258,7 @@ export function SynergyDetailResults() {
       controller.abort();
       setLoading(false);
     };
-  }, [deferredAllies, sortBy, t]);
+  }, [deferredAllies, t]);
 
   // 점진적 카드 mount — visibleCount를 idle frame마다 6씩 늘려 IDLE_TARGET까지 확장.
   // 사용자 click의 commit이 30개가 아닌 6개만 처리하므로 INP duration이 줄어들고,

--- a/frontend/src/components/features/synergy/SynergyResults.tsx
+++ b/frontend/src/components/features/synergy/SynergyResults.tsx
@@ -112,7 +112,7 @@ export function SynergyResults({ compact = false }: { compact?: boolean }) {
     [l10n]
   );
 
-  // API 호출: 아군 선택 / 정렬 변경 시 (300ms 디바운스 + AbortController)
+  // API 호출: 아군 선택 시 (300ms 디바운스 + AbortController). 정렬은 클라이언트에서 처리해 CDN 키를 줄인다.
   React.useEffect(() => {
     if (selectedAllies.length === 0) {
       setTrioResults([]);
@@ -122,7 +122,7 @@ export function SynergyResults({ compact = false }: { compact?: boolean }) {
 
     const controller = new AbortController();
     const timerId = setTimeout(() => {
-      const params = new URLSearchParams({ sortBy, limit: "5000" });
+      const params = new URLSearchParams({ sortBy: "totalGames", limit: "5000" });
       if (selectedAllies[0] !== undefined) params.set("character1", String(selectedAllies[0]));
       if (selectedAllies[1] !== undefined) params.set("character2", String(selectedAllies[1]));
 
@@ -161,7 +161,7 @@ export function SynergyResults({ compact = false }: { compact?: boolean }) {
       controller.abort();
       setLoading(false);
     };
-  }, [selectedAllies, sortBy, t]);
+  }, [selectedAllies, t]);
 
   const recommendations = React.useMemo(() => {
     if (selectedAllies.length === 0) return [];

--- a/frontend/src/components/features/synergy/SynergyResults.tsx
+++ b/frontend/src/components/features/synergy/SynergyResults.tsx
@@ -72,6 +72,10 @@ function mergeTrioWeaponRowsByCharacters(rows: TrioWeaponApiRow[]): TrioResult[]
   return Array.from(merged.values());
 }
 
+function sortCharacterPair(characters: number[]): number[] {
+  return [...characters].sort((a, b) => a - b);
+}
+
 /**
  * 시너지 결과 Island — URL params(ally1,ally2) + localStorage(focusCharacters) 기반
  * SynergyClient에서 분리된 독립 Client Component
@@ -123,8 +127,9 @@ export function SynergyResults({ compact = false }: { compact?: boolean }) {
     const controller = new AbortController();
     const timerId = setTimeout(() => {
       const params = new URLSearchParams({ sortBy: "totalGames", limit: "5000" });
-      if (selectedAllies[0] !== undefined) params.set("character1", String(selectedAllies[0]));
-      if (selectedAllies[1] !== undefined) params.set("character2", String(selectedAllies[1]));
+      const queryAllies = sortCharacterPair(selectedAllies);
+      if (queryAllies[0] !== undefined) params.set("character1", String(queryAllies[0]));
+      if (queryAllies[1] !== undefined) params.set("character2", String(queryAllies[1]));
 
       setError(null);
 

--- a/frontend/src/components/features/trio-lab/TrioLabDetailContent.tsx
+++ b/frontend/src/components/features/trio-lab/TrioLabDetailContent.tsx
@@ -43,7 +43,7 @@ async function loadComboData(members: TrioWeaponMember[]) {
     weapon1: String(m1.weapon),
     character2: String(m2.character),
     weapon2: String(m2.weapon),
-    sortBy: "averageRP",
+    sortBy: "totalGames",
     limit: "60",
   });
 
@@ -51,7 +51,7 @@ async function loadComboData(members: TrioWeaponMember[]) {
   if (!combo) {
     const fallback = await fetchTrioWeaponRows({
       character1: String(m1.character),
-      sortBy: "averageRP",
+      sortBy: "totalGames",
       limit: "200",
     });
     combo = findExactMatch(fallback, members);

--- a/frontend/src/components/features/trio-lab/TrioLabDetailContent.tsx
+++ b/frontend/src/components/features/trio-lab/TrioLabDetailContent.tsx
@@ -36,8 +36,12 @@ function findExactMatch(
   return mergeApiRowsByComboId(rows).find((combo) => combo.id === wantedId) ?? null;
 }
 
+function sortMembersByCharacter(members: TrioWeaponMember[]): TrioWeaponMember[] {
+  return [...members].sort((a, b) => a.character - b.character);
+}
+
 async function loadComboData(members: TrioWeaponMember[]) {
-  const [m1, m2] = members;
+  const [m1, m2] = sortMembersByCharacter(members);
   const trioRows = await fetchTrioWeaponRows({
     character1: String(m1.character),
     weapon1: String(m1.weapon),

--- a/frontend/src/components/features/trio-lab/TrioLabGalleryClient.tsx
+++ b/frontend/src/components/features/trio-lab/TrioLabGalleryClient.tsx
@@ -93,15 +93,14 @@ export function TrioLabGalleryClient({ initialCombos }: TrioLabGalleryClientProp
       const normalizedState = parseTrioLabUrlState(nextParams);
       const nextUrl = nextParams.toString() ? `${pathname}?${nextParams.toString()}` : pathname;
 
+      if (normalizedState.sort !== currentState.sort) {
+        setVisibleCount(PAGE_SIZE);
+      }
       setCurrentState(normalizedState);
       window.history.replaceState(window.history.state, "", nextUrl);
     },
-    [pathname, searchParams]
+    [currentState.sort, pathname, searchParams]
   );
-
-  React.useEffect(() => {
-    setVisibleCount(PAGE_SIZE);
-  }, [sort]);
 
   React.useEffect(() => {
     if (!didMountRef.current) {
@@ -371,11 +370,11 @@ export function TrioLabGalleryClient({ initialCombos }: TrioLabGalleryClientProp
               <button
                 type="button"
                 onClick={() =>
-                  setVisibleCount((count) => Math.min(count + PAGE_SIZE, combos.length))
+                  setVisibleCount((count) => Math.min(count + PAGE_SIZE, sortedCombos.length))
                 }
                 className="inline-flex min-h-[42px] items-center justify-center rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-3)] px-5 text-xs font-semibold text-[var(--color-foreground)] transition-colors hover:border-[var(--color-primary)] hover:bg-[var(--color-primary)]/10"
               >
-                더보기 · {Math.min(PAGE_SIZE, combos.length - visibleCount)}개
+                더보기 · {Math.min(PAGE_SIZE, sortedCombos.length - visibleCount)}개
               </button>
             </div>
           ) : null}

--- a/frontend/src/components/features/trio-lab/TrioLabGalleryClient.tsx
+++ b/frontend/src/components/features/trio-lab/TrioLabGalleryClient.tsx
@@ -80,8 +80,12 @@ export function TrioLabGalleryClient({ initialCombos }: TrioLabGalleryClientProp
     () => buildTrioLabQueryString(currentState),
     [currentState]
   );
-  const visibleCombos = React.useMemo(() => combos.slice(0, visibleCount), [combos, visibleCount]);
-  const hasMore = visibleCount < combos.length;
+  const sortedCombos = React.useMemo(() => sortTrioWeaponCombos(combos, sort), [combos, sort]);
+  const visibleCombos = React.useMemo(
+    () => sortedCombos.slice(0, visibleCount),
+    [sortedCombos, visibleCount]
+  );
+  const hasMore = visibleCount < sortedCombos.length;
 
   const replaceUrlState = React.useCallback(
     (nextState: TrioLabUrlState) => {
@@ -96,6 +100,10 @@ export function TrioLabGalleryClient({ initialCombos }: TrioLabGalleryClientProp
   );
 
   React.useEffect(() => {
+    setVisibleCount(PAGE_SIZE);
+  }, [sort]);
+
+  React.useEffect(() => {
     if (!didMountRef.current) {
       didMountRef.current = true;
       return;
@@ -106,7 +114,7 @@ export function TrioLabGalleryClient({ initialCombos }: TrioLabGalleryClientProp
     setError(null);
 
     const poolCodes = poolKey ? poolKey.split(",").map(Number) : [];
-    const requests = buildTrioWeaponSearchRequests(poolCodes, sort);
+    const requests = buildTrioWeaponSearchRequests(poolCodes);
 
     Promise.all(
       requests.map((requestParams) => {
@@ -122,7 +130,7 @@ export function TrioLabGalleryClient({ initialCombos }: TrioLabGalleryClientProp
       .then((responses) => {
         const rows = responses.flatMap((data) => data.results ?? []);
         const filtered = filterRowsByPool(rows, poolCodes);
-        setCombos(sortTrioWeaponCombos(mergeApiRowsByComboId(filtered), sort));
+        setCombos(mergeApiRowsByComboId(filtered));
         setVisibleCount(PAGE_SIZE);
       })
       .catch((err: unknown) => {
@@ -134,7 +142,7 @@ export function TrioLabGalleryClient({ initialCombos }: TrioLabGalleryClientProp
       });
 
     return () => controller.abort();
-  }, [poolKey, sort]);
+  }, [poolKey]);
 
   const toggleCharacter = React.useCallback(
     (code: number) => {

--- a/frontend/src/components/features/trio-lab/searchRequests.ts
+++ b/frontend/src/components/features/trio-lab/searchRequests.ts
@@ -1,8 +1,9 @@
 import characterBestWeapons from "@/../const/characterBestWeapons.json";
-import type { ApiTrioWeaponRow, TrioSortBy } from "./types";
+import type { ApiTrioWeaponRow } from "./types";
 
 const EXACT_FANOUT_LIMIT = 12;
 const REQUEST_LIMIT = "5000";
+const CANONICAL_SORT_BY = "totalGames";
 
 const weaponData = characterBestWeapons as Record<
   string,
@@ -16,20 +17,16 @@ function getCharacterWeapons(characterCode: number): number[] {
   return weapons.map((weapon) => weapon.weaponCode).filter((weaponCode) => weaponCode > 0);
 }
 
-function buildPairRequest(charA: number, charB: number, sort: TrioSortBy): TrioWeaponSearchRequest {
+function buildPairRequest(charA: number, charB: number): TrioWeaponSearchRequest {
   return {
-    sortBy: sort,
+    sortBy: CANONICAL_SORT_BY,
     limit: REQUEST_LIMIT,
     character1: String(Math.min(charA, charB)),
     character2: String(Math.max(charA, charB)),
   };
 }
 
-function buildExactPairWeaponRequests(
-  charA: number,
-  charB: number,
-  sort: TrioSortBy
-): TrioWeaponSearchRequest[] {
+function buildExactPairWeaponRequests(charA: number, charB: number): TrioWeaponSearchRequest[] {
   const weaponsA = getCharacterWeapons(charA);
   const weaponsB = getCharacterWeapons(charB);
   if (weaponsA.length === 0 || weaponsB.length === 0) return [];
@@ -42,7 +39,7 @@ function buildExactPairWeaponRequests(
   for (const weapon1 of weaponList1) {
     for (const weapon2 of weaponList2) {
       requests.push({
-        sortBy: sort,
+        sortBy: CANONICAL_SORT_BY,
         limit: REQUEST_LIMIT,
         character1: String(char1),
         weapon1: String(weapon1),
@@ -79,27 +76,24 @@ export function filterRowsByPool(rows: ApiTrioWeaponRow[], pool: number[]) {
   });
 }
 
-export function buildTrioWeaponSearchRequests(
-  pool: number[],
-  sort: TrioSortBy
-): TrioWeaponSearchRequest[] {
-  const base = { sortBy: sort, limit: REQUEST_LIMIT };
+export function buildTrioWeaponSearchRequests(pool: number[]): TrioWeaponSearchRequest[] {
+  const base = { sortBy: CANONICAL_SORT_BY, limit: REQUEST_LIMIT };
   if (pool.length === 0) return [base];
   if (pool.length === 1) return [{ ...base, character1: String(pool[0]) }];
 
   if (pool.length === 2) {
-    const exactRequests = buildExactPairWeaponRequests(pool[0], pool[1], sort);
-    return exactRequests.length > 0 ? exactRequests : [buildPairRequest(pool[0], pool[1], sort)];
+    const exactRequests = buildExactPairWeaponRequests(pool[0], pool[1]);
+    return exactRequests.length > 0 ? exactRequests : [buildPairRequest(pool[0], pool[1])];
   }
 
   const exactPair = pickSmallestExactPair(pool);
   if (exactPair) {
-    return buildExactPairWeaponRequests(exactPair[0], exactPair[1], sort);
+    return buildExactPairWeaponRequests(exactPair[0], exactPair[1]);
   }
 
   return [
-    buildPairRequest(pool[0], pool[1], sort),
-    buildPairRequest(pool[0], pool[2], sort),
-    buildPairRequest(pool[1], pool[2], sort),
+    buildPairRequest(pool[0], pool[1]),
+    buildPairRequest(pool[0], pool[2]),
+    buildPairRequest(pool[1], pool[2]),
   ];
 }

--- a/frontend/src/lib/cache.ts
+++ b/frontend/src/lib/cache.ts
@@ -5,6 +5,7 @@
  *   A. 불변 (종료 패치)  → "immutable"
  *   B. 준정적 (패치 목록) → "slow"
  *   C. 준동적 (통계)     → "daily"
+ *   C-1. 패치 단위 캐릭터 상세 통계 → "character-stats"
  *   D. 고카디널리티 사전집계 (trios)        → "frequent"
  *   E. 고카디널리티 사전집계 + 키 폭발 (trios-weapon) → "stats-long"
  *
@@ -13,12 +14,19 @@
  * Stale window 는 invalidation 실패 시의 safety net.
  */
 
-export type CachePreset = "immutable" | "slow" | "daily" | "frequent" | "stats-long";
+export type CachePreset =
+  | "immutable"
+  | "slow"
+  | "daily"
+  | "character-stats"
+  | "frequent"
+  | "stats-long";
 
 const CACHE_CONTROL: Record<CachePreset, string> = {
   immutable: "public, max-age=86400, s-maxage=604800, stale-while-revalidate=86400",
   slow: "public, max-age=300, s-maxage=3600, stale-while-revalidate=600",
   daily: "public, max-age=300, s-maxage=1800, stale-while-revalidate=300",
+  "character-stats": "public, max-age=300, s-maxage=21600, stale-while-revalidate=3600",
   // frequent (trios): L3 5m / L2 1h / SWR 7d — tag invalidation 의존, stale 7d 안전망
   frequent: "public, max-age=300, s-maxage=3600, stale-while-revalidate=604800",
   // stats-long (trios-weapon): L3 10m / L2 7d / SWR 7d — 최고 카디널리티, 가장 길게


### PR DESCRIPTION
## 변경 사항
  - `/api/stats/trios-weapon` 요청의 CDN 캐시 키를 정규화했습니다.
    - 조합 조회 API 요청의 `sortBy`를 `totalGames`로 통일했습니다.
    - 정렬 변경 시 API를 다시 호출하지 않고, 클라이언트에서 기존 결과를 재정렬하도록 변경했습니다.
    - `character1/character2` 순서를 정규화해 동일 조합이 다른 URL로 캐시되는 문제를 줄였습니다.
    - 무기 정보가 있는 요청에서는 캐릭터 순서 변경에 맞춰 `weapon1/weapon2`도 함께 정규화했습니다.

  - `/api/character/stats/[characterCode]`의 CDN 캐시 TTL을 확대했습니다.
    - 기존 `daily` 프리셋의 CDN TTL 30분 대신, 캐릭터 상세 통계 전용 프리셋을 추가했습니다.
    - 캐릭터 상세 통계 응답의 CDN TTL을 6시간으로 설정했습니다.


## 테스트 결과 (테스트를 했으면)
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.