### PR TITLE
[feat] 멀티서치용 백엔드 구현

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,6 +10,9 @@ BSER_API_KEY=your-bser-api-key
 PORT=4000
 NODE_ENV=development
 FRONTEND_ORIGINS=https://erwagg.com,https://www.erwagg.com,http://localhost:3000,http://localhost:3001
+ENABLE_COLLECTOR=false
+MULTI_SEARCH_SEASON_ID=39
+MULTI_SEARCH_MATCHING_MODE=3
 
 # Redis
 REDIS_HOST=localhost

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -18,6 +18,7 @@ import { ItemsModule } from './modules/items/items.module';
 import { FeedbackModule } from './modules/feedback/feedback.module';
 import { CollectModule } from './modules/collect/collect.module';
 import { SynergyPairsModule } from './modules/synergy-pairs/synergy-pairs.module';
+import { MultiSearchModule } from './modules/multi-search/multi-search.module';
 
 @Module({
   imports: [
@@ -37,6 +38,7 @@ import { SynergyPairsModule } from './modules/synergy-pairs/synergy-pairs.module
     ItemsModule,
     FeedbackModule,
     SynergyPairsModule,
+    MultiSearchModule,
     CollectModule,
   ],
   controllers: [HealthController],

--- a/backend/src/modules/collect/bser-api.service.ts
+++ b/backend/src/modules/collect/bser-api.service.ts
@@ -11,6 +11,12 @@ export interface BSERUserByNickname {
   userId: string;
 }
 
+export type BSERLookupResult =
+  | { status: 'found'; user: BSERUserByNickname }
+  | { status: 'not_found' }
+  | { status: 'not_configured' }
+  | { status: 'unavailable'; statusCode?: number; message?: string };
+
 export interface BSERUserStatsResponse {
   code: number;
   message: string;
@@ -41,6 +47,12 @@ export interface BSERUserSeasonStats {
   top7: number;
   characterStats?: BSERUserCharacterStats[];
 }
+
+export type BSERUserStatsResult =
+  | { status: 'found'; stats: BSERUserSeasonStats }
+  | { status: 'not_found' }
+  | { status: 'not_configured' }
+  | { status: 'unavailable'; statusCode?: number; message?: string };
 
 export interface BSERUserCharacterStats {
   characterCode: number;
@@ -92,9 +104,13 @@ export class BserApiService {
   private readonly logger = new Logger(BserApiService.name);
   private readonly apiKey: string;
   private readonly baseUrl = 'https://open-api.bser.io';
+  private readonly timeoutMs: number;
+  private readonly maxRetries: number;
 
   constructor(private config: ConfigService) {
     this.apiKey = this.config.get<string>('BSER_API_KEY', '');
+    this.timeoutMs = this.config.get<number>('BSER_API_TIMEOUT_MS', 4_000);
+    this.maxRetries = this.config.get<number>('BSER_API_RETRIES', 1);
   }
 
   async fetchGame(gameId: number): Promise<BSERGameResponse | null> {
@@ -121,7 +137,10 @@ export class BserApiService {
     }
   }
 
-  async fetchRankTop(seasonId: number, matchingTeamMode: number): Promise<number | null> {
+  async fetchRankTop(
+    seasonId: number,
+    matchingTeamMode: number,
+  ): Promise<number | null> {
     if (!this.apiKey) return null;
 
     try {
@@ -139,28 +158,45 @@ export class BserApiService {
     }
   }
 
-  async findUserByNickname(nickname: string): Promise<BSERUserByNickname | null> {
-    if (!this.apiKey) return null;
+  async findUserByNickname(
+    nickname: string,
+  ): Promise<BSERUserByNickname | null> {
+    const result = await this.findUserByNicknameDetailed(nickname);
+    return result.status === 'found' ? result.user : null;
+  }
+
+  async findUserByNicknameDetailed(
+    nickname: string,
+  ): Promise<BSERLookupResult> {
+    if (!this.apiKey) return { status: 'not_configured' };
 
     try {
       const url = new URL(`${this.baseUrl}/v1/user/nickname`);
       url.searchParams.set('query', nickname);
-      const res = await fetch(url, {
+      const res = await this.fetchWithRetry(url, {
         headers: { 'x-api-key': this.apiKey },
       });
 
-      if (!res.ok) return null;
+      if (res.status === 404) return { status: 'not_found' };
+      if (!res.ok) {
+        return {
+          status: 'unavailable',
+          statusCode: res.status,
+          message: res.statusText,
+        };
+      }
 
       const json = (await res.json()) as {
         code?: number;
         user?: BSERUserByNickname;
       };
 
-      if (json.code !== 200 || !json.user?.userId) return null;
-      return json.user;
+      if (json.code !== 200 || !json.user?.userId)
+        return { status: 'not_found' };
+      return { status: 'found', user: json.user };
     } catch (err) {
       this.logger.warn(`BSER nickname 조회 실패: ${(err as Error).message}`);
-      return null;
+      return { status: 'unavailable', message: (err as Error).message };
     }
   }
 
@@ -169,22 +205,89 @@ export class BserApiService {
     seasonId: number,
     matchingMode: number,
   ): Promise<BSERUserSeasonStats | null> {
-    if (!this.apiKey) return null;
+    const result = await this.fetchUserStatsDetailed(
+      userId,
+      seasonId,
+      matchingMode,
+    );
+    return result.status === 'found' ? result.stats : null;
+  }
+
+  async fetchUserStatsDetailed(
+    userId: string,
+    seasonId: number,
+    matchingMode: number,
+  ): Promise<BSERUserStatsResult> {
+    if (!this.apiKey) return { status: 'not_configured' };
 
     try {
-      const res = await fetch(
+      const res = await this.fetchWithRetry(
         `${this.baseUrl}/v2/user/stats/uid/${encodeURIComponent(userId)}/${seasonId}/${matchingMode}`,
         { headers: { 'x-api-key': this.apiKey } },
       );
 
-      if (!res.ok) return null;
+      if (res.status === 404) return { status: 'not_found' };
+      if (!res.ok) {
+        return {
+          status: 'unavailable',
+          statusCode: res.status,
+          message: res.statusText,
+        };
+      }
 
       const json = (await res.json()) as BSERUserStatsResponse;
-      if (json.code !== 200) return null;
-      return json.userStats?.[0] ?? null;
+      if (json.code !== 200) return { status: 'not_found' };
+      const stats = json.userStats?.[0];
+      return stats ? { status: 'found', stats } : { status: 'not_found' };
     } catch (err) {
       this.logger.warn(`BSER user stats 조회 실패: ${(err as Error).message}`);
-      return null;
+      return { status: 'unavailable', message: (err as Error).message };
     }
   }
+
+  private async fetchWithTimeout(
+    input: Parameters<typeof fetch>[0],
+    init: Parameters<typeof fetch>[1],
+  ): Promise<Response> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      return await fetch(input, { ...init, signal: controller.signal });
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private async fetchWithRetry(
+    input: Parameters<typeof fetch>[0],
+    init: Parameters<typeof fetch>[1],
+  ): Promise<Response> {
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt <= this.maxRetries; attempt += 1) {
+      try {
+        const response = await this.fetchWithTimeout(input, init);
+        if (attempt < this.maxRetries && isRetryableStatus(response.status)) {
+          await sleep(150 * (attempt + 1));
+          continue;
+        }
+        return response;
+      } catch (err) {
+        lastError = err;
+        if (attempt >= this.maxRetries) break;
+        await sleep(150 * (attempt + 1));
+      }
+    }
+
+    throw lastError;
+  }
+}
+
+function isRetryableStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/backend/src/modules/collect/bser-api.service.ts
+++ b/backend/src/modules/collect/bser-api.service.ts
@@ -6,6 +6,55 @@ export interface BSERGameResponse {
   userGames: BSERPlayerData[];
 }
 
+export interface BSERUserByNickname {
+  nickname: string;
+  userId: string;
+}
+
+export interface BSERUserStatsResponse {
+  code: number;
+  message: string;
+  userStats?: BSERUserSeasonStats[];
+}
+
+export interface BSERUserSeasonStats {
+  seasonId: number;
+  matchingMode: number;
+  matchingTeamMode: number;
+  mmr: number;
+  rank: number;
+  rankSize: number;
+  totalGames: number;
+  totalWins: number;
+  totalTeamKills: number;
+  totalDeaths: number;
+  escapeCount: number;
+  rankPercent: number;
+  averageRank: number;
+  averageKills: number;
+  averageAssistants: number;
+  averageHunts: number;
+  top1: number;
+  top2: number;
+  top3: number;
+  top5: number;
+  top7: number;
+  characterStats?: BSERUserCharacterStats[];
+}
+
+export interface BSERUserCharacterStats {
+  characterCode: number;
+  totalGames: number;
+  usages: number;
+  maxKillings: number;
+  top3: number;
+  wins: number;
+  mostUsedSkinCode?: number;
+  latestUsedSkinCode?: number;
+  top3Rate: number;
+  averageRank: number;
+}
+
 export interface BSERPlayerData {
   gameId: number;
   teamNumber: number;
@@ -86,6 +135,55 @@ export class BserApiService {
       const ranks = json.topRanks ?? [];
       return ranks.length >= 1000 ? ranks[999].mmr : null;
     } catch {
+      return null;
+    }
+  }
+
+  async findUserByNickname(nickname: string): Promise<BSERUserByNickname | null> {
+    if (!this.apiKey) return null;
+
+    try {
+      const url = new URL(`${this.baseUrl}/v1/user/nickname`);
+      url.searchParams.set('query', nickname);
+      const res = await fetch(url, {
+        headers: { 'x-api-key': this.apiKey },
+      });
+
+      if (!res.ok) return null;
+
+      const json = (await res.json()) as {
+        code?: number;
+        user?: BSERUserByNickname;
+      };
+
+      if (json.code !== 200 || !json.user?.userId) return null;
+      return json.user;
+    } catch (err) {
+      this.logger.warn(`BSER nickname 조회 실패: ${(err as Error).message}`);
+      return null;
+    }
+  }
+
+  async fetchUserStats(
+    userId: string,
+    seasonId: number,
+    matchingMode: number,
+  ): Promise<BSERUserSeasonStats | null> {
+    if (!this.apiKey) return null;
+
+    try {
+      const res = await fetch(
+        `${this.baseUrl}/v2/user/stats/uid/${encodeURIComponent(userId)}/${seasonId}/${matchingMode}`,
+        { headers: { 'x-api-key': this.apiKey } },
+      );
+
+      if (!res.ok) return null;
+
+      const json = (await res.json()) as BSERUserStatsResponse;
+      if (json.code !== 200) return null;
+      return json.userStats?.[0] ?? null;
+    } catch (err) {
+      this.logger.warn(`BSER user stats 조회 실패: ${(err as Error).message}`);
       return null;
     }
   }

--- a/backend/src/modules/collect/collect.module.ts
+++ b/backend/src/modules/collect/collect.module.ts
@@ -10,5 +10,6 @@ import { CacheWarmingService } from './cache-warming.service';
 @Module({
   imports: [CharacterModule, StatsModule, MetaModule],
   providers: [CollectService, BserApiService, ParserService, CacheWarmingService],
+  exports: [BserApiService],
 })
 export class CollectModule {}

--- a/backend/src/modules/collect/collect.service.ts
+++ b/backend/src/modules/collect/collect.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { SupabaseService } from '../../common/database/supabase.service';
@@ -18,10 +19,15 @@ export class CollectService {
     private readonly bserApi: BserApiService,
     private readonly parser: ParserService,
     private readonly eventEmitter: EventEmitter2,
+    private readonly config: ConfigService,
   ) {}
 
   @Cron(CronExpression.EVERY_5_MINUTES)
   async handleCron() {
+    if (this.config.get<string>('ENABLE_COLLECTOR') !== 'true') {
+      return;
+    }
+
     if (this.isRunning) {
       this.logger.warn('이전 수집 사이클 진행 중 — 스킵');
       return;

--- a/backend/src/modules/multi-search/dto/multi-search-players.dto.ts
+++ b/backend/src/modules/multi-search/dto/multi-search-players.dto.ts
@@ -1,0 +1,22 @@
+import { ArrayMaxSize, ArrayMinSize, IsArray, IsInt, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
+
+export class MultiSearchPlayersDto {
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(3)
+  @IsString({ each: true })
+  @MaxLength(16, { each: true })
+  nicknames: string[];
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(99)
+  seasonId?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(10)
+  matchingMode?: number;
+}

--- a/backend/src/modules/multi-search/multi-search.controller.ts
+++ b/backend/src/modules/multi-search/multi-search.controller.ts
@@ -1,7 +1,10 @@
 import { Body, Controller, HttpCode, Post } from '@nestjs/common';
 import { RateLimit } from '../../common/guards/rate-limit.guard';
 import { MultiSearchPlayersDto } from './dto/multi-search-players.dto';
-import { MultiSearchService } from './multi-search.service';
+import {
+  MultiSearchPlayersResponse,
+  MultiSearchService,
+} from './multi-search.service';
 
 @Controller('multi-search')
 export class MultiSearchController {
@@ -10,7 +13,13 @@ export class MultiSearchController {
   @Post('players')
   @HttpCode(200)
   @RateLimit(30, 60)
-  searchPlayers(@Body() body: MultiSearchPlayersDto): Promise<unknown> {
-    return this.multiSearchService.searchPlayers(body.nicknames, body.seasonId, body.matchingMode);
+  searchPlayers(
+    @Body() body: MultiSearchPlayersDto,
+  ): Promise<MultiSearchPlayersResponse> {
+    return this.multiSearchService.searchPlayers(
+      body.nicknames,
+      body.seasonId,
+      body.matchingMode,
+    );
   }
 }

--- a/backend/src/modules/multi-search/multi-search.controller.ts
+++ b/backend/src/modules/multi-search/multi-search.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, HttpCode, Post } from '@nestjs/common';
+import { RateLimit } from '../../common/guards/rate-limit.guard';
 import { MultiSearchPlayersDto } from './dto/multi-search-players.dto';
 import { MultiSearchService } from './multi-search.service';
 
@@ -8,6 +9,7 @@ export class MultiSearchController {
 
   @Post('players')
   @HttpCode(200)
+  @RateLimit(30, 60)
   searchPlayers(@Body() body: MultiSearchPlayersDto): Promise<unknown> {
     return this.multiSearchService.searchPlayers(body.nicknames, body.seasonId, body.matchingMode);
   }

--- a/backend/src/modules/multi-search/multi-search.controller.ts
+++ b/backend/src/modules/multi-search/multi-search.controller.ts
@@ -1,0 +1,14 @@
+import { Body, Controller, HttpCode, Post } from '@nestjs/common';
+import { MultiSearchPlayersDto } from './dto/multi-search-players.dto';
+import { MultiSearchService } from './multi-search.service';
+
+@Controller('multi-search')
+export class MultiSearchController {
+  constructor(private readonly multiSearchService: MultiSearchService) {}
+
+  @Post('players')
+  @HttpCode(200)
+  searchPlayers(@Body() body: MultiSearchPlayersDto): Promise<unknown> {
+    return this.multiSearchService.searchPlayers(body.nicknames, body.seasonId, body.matchingMode);
+  }
+}

--- a/backend/src/modules/multi-search/multi-search.module.ts
+++ b/backend/src/modules/multi-search/multi-search.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { CollectModule } from '../collect/collect.module';
+import { MultiSearchController } from './multi-search.controller';
+import { MultiSearchService } from './multi-search.service';
+
+@Module({
+  imports: [CollectModule],
+  controllers: [MultiSearchController],
+  providers: [MultiSearchService],
+})
+export class MultiSearchModule {}

--- a/backend/src/modules/multi-search/multi-search.service.ts
+++ b/backend/src/modules/multi-search/multi-search.service.ts
@@ -1,7 +1,13 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { RedisService } from '../../common/redis/redis.service';
-import { BserApiService, BSERUserByNickname, BSERUserSeasonStats } from '../collect/bser-api.service';
+import {
+  BserApiService,
+  BSERLookupResult,
+  BSERUserByNickname,
+  BSERUserSeasonStats,
+  BSERUserStatsResult,
+} from '../collect/bser-api.service';
 
 const DEFAULT_SEASON_ID = 39;
 const DEFAULT_MATCHING_MODE = 3;
@@ -18,9 +24,18 @@ type StatsCache =
   | { status: 'found'; stats: BSERUserSeasonStats }
   | { status: 'not_found' };
 
-interface PlayerSearchResult {
+export type MultiSearchPlayerStatus = 'ok' | 'not_found' | 'no_stats' | 'error';
+
+export type MultiSearchFailureReason =
+  | 'nickname_not_found'
+  | 'season_stats_not_found'
+  | 'bser_api_key_missing'
+  | 'bser_api_unavailable'
+  | 'unknown_error';
+
+export interface MultiSearchPlayerResult {
   input: string;
-  status: 'ok' | 'not_found' | 'no_stats' | 'error';
+  status: MultiSearchPlayerStatus;
   nickname?: string;
   seasonId?: number;
   matchingMode?: number;
@@ -45,7 +60,24 @@ interface PlayerSearchResult {
     averageRank: number;
     maxKillings: number;
   }>;
-  reason?: string;
+  reason?: MultiSearchFailureReason;
+}
+
+export interface MultiSearchPlayersResponse {
+  seasonId: number;
+  matchingMode: number;
+  results: MultiSearchPlayerResult[];
+  summary: {
+    requested: number;
+    ok: number;
+    failed: number;
+  };
+}
+
+class MultiSearchUpstreamError extends Error {
+  constructor(readonly reason: MultiSearchFailureReason) {
+    super(reason);
+  }
 }
 
 @Injectable()
@@ -58,24 +90,42 @@ export class MultiSearchService {
     private readonly redis: RedisService,
     config: ConfigService,
   ) {
-    this.defaultSeasonId = config.get<number>('MULTI_SEARCH_SEASON_ID', DEFAULT_SEASON_ID);
-    this.defaultMatchingMode = config.get<number>('MULTI_SEARCH_MATCHING_MODE', DEFAULT_MATCHING_MODE);
+    this.defaultSeasonId = config.get<number>(
+      'MULTI_SEARCH_SEASON_ID',
+      DEFAULT_SEASON_ID,
+    );
+    this.defaultMatchingMode = config.get<number>(
+      'MULTI_SEARCH_MATCHING_MODE',
+      DEFAULT_MATCHING_MODE,
+    );
   }
 
-  async searchPlayers(nicknames: string[], seasonId?: number, matchingMode?: number) {
+  async searchPlayers(
+    nicknames: string[],
+    seasonId?: number,
+    matchingMode?: number,
+  ): Promise<MultiSearchPlayersResponse> {
     const normalizedNicknames = this.normalizeNicknames(nicknames);
     const targetSeasonId = seasonId ?? this.defaultSeasonId;
     const targetMatchingMode = matchingMode ?? this.defaultMatchingMode;
 
-    const results: PlayerSearchResult[] = [];
+    const results: MultiSearchPlayerResult[] = [];
     for (const nickname of normalizedNicknames) {
-      results.push(await this.searchPlayer(nickname, targetSeasonId, targetMatchingMode));
+      results.push(
+        await this.searchPlayer(nickname, targetSeasonId, targetMatchingMode),
+      );
     }
+    const ok = results.filter((result) => result.status === 'ok').length;
 
     return {
       seasonId: targetSeasonId,
       matchingMode: targetMatchingMode,
       results,
+      summary: {
+        requested: normalizedNicknames.length,
+        ok,
+        failed: results.length - ok,
+      },
     };
   }
 
@@ -95,7 +145,9 @@ export class MultiSearchService {
       throw new BadRequestException('검색할 닉네임을 입력해주세요.');
     }
     if (normalized.length > MAX_NICKNAMES) {
-      throw new BadRequestException(`닉네임은 최대 ${MAX_NICKNAMES}개까지 검색할 수 있습니다.`);
+      throw new BadRequestException(
+        `닉네임은 최대 ${MAX_NICKNAMES}개까지 검색할 수 있습니다.`,
+      );
     }
 
     return normalized;
@@ -105,14 +157,22 @@ export class MultiSearchService {
     nickname: string,
     seasonId: number,
     matchingMode: number,
-  ): Promise<PlayerSearchResult> {
+  ): Promise<MultiSearchPlayerResult> {
     try {
       const user = await this.findUser(nickname);
       if (!user) {
-        return { input: nickname, status: 'not_found', reason: 'nickname_not_found' };
+        return {
+          input: nickname,
+          status: 'not_found',
+          reason: 'nickname_not_found',
+        };
       }
 
-      const stats = await this.fetchUserStats(user.userId, seasonId, matchingMode);
+      const stats = await this.fetchUserStats(
+        user.userId,
+        seasonId,
+        matchingMode,
+      );
       if (!stats) {
         return {
           input: nickname,
@@ -127,17 +187,24 @@ export class MultiSearchService {
       return {
         input: nickname,
         status: 'error',
-        reason: error instanceof Error ? error.message : 'unknown_error',
+        reason:
+          error instanceof MultiSearchUpstreamError
+            ? error.reason
+            : 'unknown_error',
       };
     }
   }
 
   private async findUser(nickname: string) {
     const cacheKey = `bser:nickname:${this.cacheKeyPart(nickname)}`;
-    const cached = await this.redis.getOrSet<LookupCache>(cacheKey, NICKNAME_CACHE_TTL_SEC, async () => {
-      const user = await this.bserApi.findUserByNickname(nickname);
-      return user ? { status: 'found', user } : { status: 'not_found' };
-    });
+    const cached = await this.redis.getOrSet<LookupCache>(
+      cacheKey,
+      NICKNAME_CACHE_TTL_SEC,
+      async () => {
+        const result = await this.bserApi.findUserByNicknameDetailed(nickname);
+        return toLookupCache(result);
+      },
+    );
 
     if (cached.status === 'not_found') {
       await this.redis.set(cacheKey, cached, NOT_FOUND_CACHE_TTL_SEC);
@@ -147,12 +214,24 @@ export class MultiSearchService {
     return cached.user;
   }
 
-  private async fetchUserStats(userId: string, seasonId: number, matchingMode: number) {
+  private async fetchUserStats(
+    userId: string,
+    seasonId: number,
+    matchingMode: number,
+  ) {
     const cacheKey = `bser:user-stats:${this.cacheKeyPart(userId)}:${seasonId}:${matchingMode}`;
-    const cached = await this.redis.getOrSet<StatsCache>(cacheKey, USER_STATS_CACHE_TTL_SEC, async () => {
-      const stats = await this.bserApi.fetchUserStats(userId, seasonId, matchingMode);
-      return stats ? { status: 'found', stats } : { status: 'not_found' };
-    });
+    const cached = await this.redis.getOrSet<StatsCache>(
+      cacheKey,
+      USER_STATS_CACHE_TTL_SEC,
+      async () => {
+        const result = await this.bserApi.fetchUserStatsDetailed(
+          userId,
+          seasonId,
+          matchingMode,
+        );
+        return toStatsCache(result);
+      },
+    );
 
     return cached.status === 'found' ? cached.stats : null;
   }
@@ -161,7 +240,7 @@ export class MultiSearchService {
     input: string,
     user: BSERUserByNickname,
     stats: BSERUserSeasonStats,
-  ): PlayerSearchResult {
+  ): MultiSearchPlayerResult {
     return {
       input,
       status: 'ok',
@@ -203,4 +282,21 @@ export class MultiSearchService {
 function toPercent(numerator: number, denominator: number) {
   if (!denominator) return 0;
   return Math.round((numerator / denominator) * 10000) / 100;
+}
+
+function toLookupCache(result: BSERLookupResult): LookupCache {
+  if (result.status === 'found') return { status: 'found', user: result.user };
+  if (result.status === 'not_found') return { status: 'not_found' };
+  if (result.status === 'not_configured')
+    throw new MultiSearchUpstreamError('bser_api_key_missing');
+  throw new MultiSearchUpstreamError('bser_api_unavailable');
+}
+
+function toStatsCache(result: BSERUserStatsResult): StatsCache {
+  if (result.status === 'found')
+    return { status: 'found', stats: result.stats };
+  if (result.status === 'not_found') return { status: 'not_found' };
+  if (result.status === 'not_configured')
+    throw new MultiSearchUpstreamError('bser_api_key_missing');
+  throw new MultiSearchUpstreamError('bser_api_unavailable');
 }

--- a/backend/src/modules/multi-search/multi-search.service.ts
+++ b/backend/src/modules/multi-search/multi-search.service.ts
@@ -197,21 +197,22 @@ export class MultiSearchService {
 
   private async findUser(nickname: string) {
     const cacheKey = `bser:nickname:${this.cacheKeyPart(nickname)}`;
-    const cached = await this.redis.getOrSet<LookupCache>(
-      cacheKey,
-      NICKNAME_CACHE_TTL_SEC,
-      async () => {
-        const result = await this.bserApi.findUserByNicknameDetailed(nickname);
-        return toLookupCache(result);
-      },
-    );
-
-    if (cached.status === 'not_found') {
-      await this.redis.set(cacheKey, cached, NOT_FOUND_CACHE_TTL_SEC);
-      return null;
+    const cached = await this.redis.get<LookupCache>(cacheKey);
+    if (cached) {
+      return cached.status === 'found' ? cached.user : null;
     }
 
-    return cached.user;
+    const result = await this.bserApi.findUserByNicknameDetailed(nickname);
+    const cacheValue = toLookupCache(result);
+    await this.redis.set(
+      cacheKey,
+      cacheValue,
+      cacheValue.status === 'found'
+        ? NICKNAME_CACHE_TTL_SEC
+        : NOT_FOUND_CACHE_TTL_SEC,
+    );
+
+    return cacheValue.status === 'found' ? cacheValue.user : null;
   }
 
   private async fetchUserStats(

--- a/backend/src/modules/multi-search/multi-search.service.ts
+++ b/backend/src/modules/multi-search/multi-search.service.ts
@@ -1,0 +1,206 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { RedisService } from '../../common/redis/redis.service';
+import { BserApiService, BSERUserByNickname, BSERUserSeasonStats } from '../collect/bser-api.service';
+
+const DEFAULT_SEASON_ID = 39;
+const DEFAULT_MATCHING_MODE = 3;
+const MAX_NICKNAMES = 3;
+const NICKNAME_CACHE_TTL_SEC = 10 * 60;
+const NOT_FOUND_CACHE_TTL_SEC = 5 * 60;
+const USER_STATS_CACHE_TTL_SEC = 10 * 60;
+
+type LookupCache =
+  | { status: 'found'; user: BSERUserByNickname }
+  | { status: 'not_found' };
+
+type StatsCache =
+  | { status: 'found'; stats: BSERUserSeasonStats }
+  | { status: 'not_found' };
+
+interface PlayerSearchResult {
+  input: string;
+  status: 'ok' | 'not_found' | 'no_stats' | 'error';
+  nickname?: string;
+  seasonId?: number;
+  matchingMode?: number;
+  matchingTeamMode?: number;
+  mmr?: number;
+  rank?: number;
+  rankSize?: number;
+  totalGames?: number;
+  totalWins?: number;
+  winRate?: number;
+  top3Rate?: number;
+  averageRank?: number;
+  averageKills?: number;
+  averageAssistants?: number;
+  topCharacters?: Array<{
+    characterCode: number;
+    totalGames: number;
+    wins: number;
+    winRate: number;
+    top3: number;
+    top3Rate: number;
+    averageRank: number;
+    maxKillings: number;
+  }>;
+  reason?: string;
+}
+
+@Injectable()
+export class MultiSearchService {
+  private readonly defaultSeasonId: number;
+  private readonly defaultMatchingMode: number;
+
+  constructor(
+    private readonly bserApi: BserApiService,
+    private readonly redis: RedisService,
+    config: ConfigService,
+  ) {
+    this.defaultSeasonId = config.get<number>('MULTI_SEARCH_SEASON_ID', DEFAULT_SEASON_ID);
+    this.defaultMatchingMode = config.get<number>('MULTI_SEARCH_MATCHING_MODE', DEFAULT_MATCHING_MODE);
+  }
+
+  async searchPlayers(nicknames: string[], seasonId?: number, matchingMode?: number) {
+    const normalizedNicknames = this.normalizeNicknames(nicknames);
+    const targetSeasonId = seasonId ?? this.defaultSeasonId;
+    const targetMatchingMode = matchingMode ?? this.defaultMatchingMode;
+
+    const results: PlayerSearchResult[] = [];
+    for (const nickname of normalizedNicknames) {
+      results.push(await this.searchPlayer(nickname, targetSeasonId, targetMatchingMode));
+    }
+
+    return {
+      seasonId: targetSeasonId,
+      matchingMode: targetMatchingMode,
+      results,
+    };
+  }
+
+  private normalizeNicknames(nicknames: string[]) {
+    const seen = new Set<string>();
+    const normalized = nicknames
+      .map((nickname) => nickname.trim())
+      .filter(Boolean)
+      .filter((nickname) => {
+        const key = nickname.toLocaleLowerCase('ko-KR');
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+
+    if (normalized.length === 0) {
+      throw new BadRequestException('검색할 닉네임을 입력해주세요.');
+    }
+    if (normalized.length > MAX_NICKNAMES) {
+      throw new BadRequestException(`닉네임은 최대 ${MAX_NICKNAMES}개까지 검색할 수 있습니다.`);
+    }
+
+    return normalized;
+  }
+
+  private async searchPlayer(
+    nickname: string,
+    seasonId: number,
+    matchingMode: number,
+  ): Promise<PlayerSearchResult> {
+    try {
+      const user = await this.findUser(nickname);
+      if (!user) {
+        return { input: nickname, status: 'not_found', reason: 'nickname_not_found' };
+      }
+
+      const stats = await this.fetchUserStats(user.userId, seasonId, matchingMode);
+      if (!stats) {
+        return {
+          input: nickname,
+          status: 'no_stats',
+          nickname: user.nickname,
+          reason: 'season_stats_not_found',
+        };
+      }
+
+      return this.toPlayerSearchResult(nickname, user, stats);
+    } catch (error) {
+      return {
+        input: nickname,
+        status: 'error',
+        reason: error instanceof Error ? error.message : 'unknown_error',
+      };
+    }
+  }
+
+  private async findUser(nickname: string) {
+    const cacheKey = `bser:nickname:${this.cacheKeyPart(nickname)}`;
+    const cached = await this.redis.getOrSet<LookupCache>(cacheKey, NICKNAME_CACHE_TTL_SEC, async () => {
+      const user = await this.bserApi.findUserByNickname(nickname);
+      return user ? { status: 'found', user } : { status: 'not_found' };
+    });
+
+    if (cached.status === 'not_found') {
+      await this.redis.set(cacheKey, cached, NOT_FOUND_CACHE_TTL_SEC);
+      return null;
+    }
+
+    return cached.user;
+  }
+
+  private async fetchUserStats(userId: string, seasonId: number, matchingMode: number) {
+    const cacheKey = `bser:user-stats:${this.cacheKeyPart(userId)}:${seasonId}:${matchingMode}`;
+    const cached = await this.redis.getOrSet<StatsCache>(cacheKey, USER_STATS_CACHE_TTL_SEC, async () => {
+      const stats = await this.bserApi.fetchUserStats(userId, seasonId, matchingMode);
+      return stats ? { status: 'found', stats } : { status: 'not_found' };
+    });
+
+    return cached.status === 'found' ? cached.stats : null;
+  }
+
+  private toPlayerSearchResult(
+    input: string,
+    user: BSERUserByNickname,
+    stats: BSERUserSeasonStats,
+  ): PlayerSearchResult {
+    return {
+      input,
+      status: 'ok',
+      nickname: user.nickname,
+      seasonId: stats.seasonId,
+      matchingMode: stats.matchingMode,
+      matchingTeamMode: stats.matchingTeamMode,
+      mmr: stats.mmr,
+      rank: stats.rank,
+      rankSize: stats.rankSize,
+      totalGames: stats.totalGames,
+      totalWins: stats.totalWins,
+      winRate: toPercent(stats.totalWins, stats.totalGames),
+      top3Rate: Math.round(stats.top3 * 10000) / 100,
+      averageRank: stats.averageRank,
+      averageKills: stats.averageKills,
+      averageAssistants: stats.averageAssistants,
+      topCharacters: [...(stats.characterStats ?? [])]
+        .sort((a, b) => b.totalGames - a.totalGames)
+        .slice(0, 5)
+        .map((character) => ({
+          characterCode: character.characterCode,
+          totalGames: character.totalGames,
+          wins: character.wins,
+          winRate: toPercent(character.wins, character.totalGames),
+          top3: character.top3,
+          top3Rate: toPercent(character.top3, character.totalGames),
+          averageRank: character.averageRank,
+          maxKillings: character.maxKillings,
+        })),
+    };
+  }
+
+  private cacheKeyPart(value: string) {
+    return encodeURIComponent(value.trim().toLocaleLowerCase('ko-KR'));
+  }
+}
+
+function toPercent(numerator: number, denominator: number) {
+  if (!denominator) return 0;
+  return Math.round((numerator / denominator) * 10000) / 100;
+}

--- a/frontend/src/app/(site)/[locale]/multi-search/page.tsx
+++ b/frontend/src/app/(site)/[locale]/multi-search/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { setRequestLocale } from "next-intl/server";
 import { MultiSearchClient } from "@/components/features/multi-search/MultiSearchClient";
 import { isRouteLocale } from "@/i18n/routing";
+import { isMultiSearchEnabled } from "@/lib/featureFlags";
 import { BASE_URL } from "@/lib/siteMetadata";
 
 interface LocalePageProps {
@@ -30,6 +31,7 @@ export async function generateMetadata({ params }: LocalePageProps): Promise<Met
 export default async function MultiSearchPage({ params }: LocalePageProps) {
   const { locale } = await params;
   if (!isRouteLocale(locale)) notFound();
+  if (!isMultiSearchEnabled()) notFound();
   setRequestLocale(locale);
 
   return (

--- a/frontend/src/app/(site)/[locale]/multi-search/page.tsx
+++ b/frontend/src/app/(site)/[locale]/multi-search/page.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
+import { MultiSearchClient } from "@/components/features/multi-search/MultiSearchClient";
+import { isRouteLocale } from "@/i18n/routing";
+import { BASE_URL } from "@/lib/siteMetadata";
+
+interface LocalePageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export async function generateMetadata({ params }: LocalePageProps): Promise<Metadata> {
+  const { locale } = await params;
+  if (!isRouteLocale(locale)) notFound();
+
+  const title = "팀원 멀티서치 — 시즌 39 랭크 요약 | ER&GG";
+  const description =
+    "이터널리턴 팀원 닉네임을 한 번에 검색해 시즌 39 랭크, MMR, 승률, Top 3, 주력 캐릭터를 빠르게 확인하세요.";
+
+  return {
+    metadataBase: new URL(BASE_URL),
+    title,
+    description,
+    openGraph: { title, description, url: "/multi-search" },
+    twitter: { title, description },
+    robots: { index: false, follow: true },
+  };
+}
+
+export default async function MultiSearchPage({ params }: LocalePageProps) {
+  const { locale } = await params;
+  if (!isRouteLocale(locale)) notFound();
+  setRequestLocale(locale);
+
+  return (
+    <main className="page-shell mx-auto flex max-w-6xl flex-col gap-5 px-3 py-6 sm:px-5 sm:py-8 lg:gap-6">
+      <header className="dashboard-hero flex flex-col gap-3 p-5 sm:p-7">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="dashboard-kicker">MULTI SEARCH · 시즌 39</span>
+        </div>
+        <h1 className="dashboard-title">
+          팀원 <em>멀티서치</em>
+        </h1>
+        <p className="max-w-[46rem] text-[0.95rem] font-semibold leading-6 text-[var(--color-foreground)]/88 sm:text-base sm:leading-7">
+          닉네임 3개를 한 번에 검색해 현재 시즌 랭크 지표와 주력 캐릭터를 비교합니다.
+        </p>
+        <p className="max-w-[46rem] text-sm leading-6 text-[var(--color-muted-foreground)] sm:text-[0.95rem] sm:leading-7">
+          BSER 공식 API 기반으로 MMR, 순위, 승률, Top 3 비율, 캐릭터별 기록을 정리합니다.
+        </p>
+      </header>
+
+      <MultiSearchClient />
+    </main>
+  );
+}

--- a/frontend/src/app/api/multi-search/players/route.ts
+++ b/frontend/src/app/api/multi-search/players/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const DEFAULT_MULTI_SEARCH_API_BASE_URL = "https://ermeta-production.up.railway.app";
+
+export async function POST(request: NextRequest) {
+  const baseUrl =
+    process.env.MULTI_SEARCH_API_BASE_URL ||
+    process.env.NEST_API_BASE_URL ||
+    DEFAULT_MULTI_SEARCH_API_BASE_URL;
+
+  try {
+    const body = await request.text();
+    const response = await fetch(`${baseUrl.replace(/\/$/, "")}/multi-search/players`, {
+      method: "POST",
+      headers: {
+        "Content-Type": request.headers.get("Content-Type") || "application/json",
+      },
+      body,
+      cache: "no-store",
+    });
+
+    const text = await response.text();
+    return new NextResponse(text, {
+      status: response.status,
+      headers: {
+        "Content-Type": response.headers.get("Content-Type") || "application/json; charset=utf-8",
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch {
+    return NextResponse.json(
+      { error: "multi_search_unavailable" },
+      { status: 503, headers: { "Cache-Control": "no-store" } }
+    );
+  }
+}

--- a/frontend/src/app/api/multi-search/players/route.ts
+++ b/frontend/src/app/api/multi-search/players/route.ts
@@ -1,8 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
+import { isMultiSearchEnabled } from "@/lib/featureFlags";
 
 const DEFAULT_MULTI_SEARCH_API_BASE_URL = "https://ermeta-production.up.railway.app";
 
 export async function POST(request: NextRequest) {
+  if (!isMultiSearchEnabled()) {
+    return NextResponse.json(
+      { error: "not_found" },
+      { status: 404, headers: { "Cache-Control": "no-store" } }
+    );
+  }
+
   const baseUrl =
     process.env.MULTI_SEARCH_API_BASE_URL ||
     process.env.NEST_API_BASE_URL ||

--- a/frontend/src/app/api/multi-search/team-combos/route.ts
+++ b/frontend/src/app/api/multi-search/team-combos/route.ts
@@ -1,0 +1,232 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  mergeApiRowsByComboId,
+  recommendationScore,
+  sortTrioWeaponCombos,
+  type ApiTrioWeaponRow,
+  type TrioWeaponMember,
+  type TrioWeaponCombo,
+} from "@/components/features/trio-lab/types";
+
+const TEAM_SIZE = 3;
+const MAX_POOL_SIZE = 3;
+const TRIO_WEAPON_LIMIT = "5000";
+const NO_STORE_HEADERS = {
+  "Cache-Control": "no-store",
+};
+
+interface TeamCombosBody {
+  pools?: unknown;
+}
+
+interface PickRanking {
+  character: number;
+  weapon: number;
+  totalGames: number;
+  winRate: number;
+  averageRP: number;
+  averageRank: number;
+  bestComboIds: string[];
+}
+
+function normalizePools(pools: unknown): number[][] | null {
+  if (!Array.isArray(pools) || pools.length !== TEAM_SIZE) return null;
+
+  const normalized = pools.map((pool) => {
+    if (!Array.isArray(pool)) return null;
+    const unique = Array.from(
+      new Set(
+        pool.map((value) => Number(value)).filter((value) => Number.isInteger(value) && value > 0)
+      )
+    ).slice(0, MAX_POOL_SIZE);
+    return unique.length > 0 ? unique : null;
+  });
+
+  if (normalized.some((pool) => pool == null)) return null;
+  return normalized as number[][];
+}
+
+function comboMatchesTeamPools(combo: TrioWeaponCombo, pools: number[][]): boolean {
+  const usedCharacters = new Set<number>();
+
+  function visit(teamIndex: number): boolean {
+    if (teamIndex >= pools.length) return true;
+
+    for (const character of pools[teamIndex]) {
+      if (usedCharacters.has(character)) continue;
+      if (!combo.members.some((member) => member.character === character)) continue;
+
+      usedCharacters.add(character);
+      if (visit(teamIndex + 1)) return true;
+      usedCharacters.delete(character);
+    }
+
+    return false;
+  }
+
+  return visit(0);
+}
+
+async function fetchTeamComboRows(origin: string, pools: number[][]): Promise<ApiTrioWeaponRow[]> {
+  const requests: Promise<ApiTrioWeaponRow[]>[] = [];
+  const requestedPairs = new Set<string>();
+
+  for (let leftIndex = 0; leftIndex < pools.length; leftIndex += 1) {
+    for (let rightIndex = leftIndex + 1; rightIndex < pools.length; rightIndex += 1) {
+      for (const charA of pools[leftIndex]) {
+        for (const charB of pools[rightIndex]) {
+          if (charA === charB) continue;
+
+          const character1 = Math.min(charA, charB);
+          const character2 = Math.max(charA, charB);
+          const pairKey = `${character1}:${character2}`;
+          if (requestedPairs.has(pairKey)) continue;
+          requestedPairs.add(pairKey);
+
+          const params = new URLSearchParams({
+            sortBy: "totalGames",
+            limit: TRIO_WEAPON_LIMIT,
+            character1: String(character1),
+            character2: String(character2),
+          });
+
+          requests.push(
+            fetch(`${origin}/api/stats/trios-weapon?${params.toString()}`, {
+              cache: "no-store",
+            })
+              .then((response) => (response.ok ? response.json() : { results: [] }))
+              .then((payload: { results?: ApiTrioWeaponRow[] }) => payload.results ?? [])
+          );
+        }
+      }
+    }
+  }
+
+  const settled = await Promise.all(requests);
+  return settled.flat();
+}
+
+function findMyMember(combo: TrioWeaponCombo, myPool: number[]): TrioWeaponMember | null {
+  return combo.members.find((member) => myPool.includes(member.character)) ?? null;
+}
+
+function buildPickRankings(combos: TrioWeaponCombo[], myPool: number[]): PickRanking[] {
+  const rankings = new Map<
+    string,
+    PickRanking & { rpSum: number; rankSum: number; winSum: number }
+  >();
+
+  for (const combo of combos) {
+    const myMember = findMyMember(combo, myPool);
+    if (!myMember) continue;
+
+    const key = `${myMember.character}:${myMember.weapon}`;
+    const current = rankings.get(key) ?? {
+      character: myMember.character,
+      weapon: myMember.weapon,
+      totalGames: 0,
+      winRate: 0,
+      averageRP: 0,
+      averageRank: 0,
+      bestComboIds: [],
+      rpSum: 0,
+      rankSum: 0,
+      winSum: 0,
+    };
+
+    current.totalGames += combo.totalGames;
+    current.rpSum += combo.averageRP * combo.totalGames;
+    current.rankSum += combo.averageRank * combo.totalGames;
+    current.winSum += combo.winRate * combo.totalGames;
+    rankings.set(key, current);
+  }
+
+  return Array.from(rankings.values())
+    .map((ranking) => {
+      const bestComboIds = combos
+        .filter((combo) =>
+          combo.members.some(
+            (member) => member.character === ranking.character && member.weapon === ranking.weapon
+          )
+        )
+        .sort(
+          (a, b) =>
+            b.averageRP - a.averageRP || b.totalGames - a.totalGames || b.winRate - a.winRate
+        )
+        .map((combo) => combo.id);
+
+      return {
+        character: ranking.character,
+        weapon: ranking.weapon,
+        totalGames: ranking.totalGames,
+        winRate: ranking.totalGames > 0 ? ranking.winSum / ranking.totalGames : 0,
+        averageRP: ranking.totalGames > 0 ? ranking.rpSum / ranking.totalGames : 0,
+        averageRank: ranking.totalGames > 0 ? ranking.rankSum / ranking.totalGames : 0,
+        bestComboIds,
+      };
+    })
+    .sort(
+      (a, b) =>
+        recommendationScore({
+          id: `${b.character}-${b.weapon}`,
+          members: [
+            { character: b.character, weapon: b.weapon, mainCore: null },
+            { character: 0, weapon: 0, mainCore: null },
+            { character: 0, weapon: 0, mainCore: null },
+          ],
+          totalGames: b.totalGames,
+          winRate: b.winRate,
+          averageRP: b.averageRP,
+          averageRank: b.averageRank,
+        }) -
+        recommendationScore({
+          id: `${a.character}-${a.weapon}`,
+          members: [
+            { character: a.character, weapon: a.weapon, mainCore: null },
+            { character: 0, weapon: 0, mainCore: null },
+            { character: 0, weapon: 0, mainCore: null },
+          ],
+          totalGames: a.totalGames,
+          winRate: a.winRate,
+          averageRP: a.averageRP,
+          averageRank: a.averageRank,
+        })
+    );
+}
+
+export async function POST(request: NextRequest) {
+  let body: TeamCombosBody;
+  try {
+    body = (await request.json()) as TeamCombosBody;
+  } catch {
+    return NextResponse.json(
+      { error: "요청 본문을 확인해주세요." },
+      { status: 400, headers: NO_STORE_HEADERS }
+    );
+  }
+
+  const pools = normalizePools(body.pools);
+  if (!pools) {
+    return NextResponse.json(
+      { error: "팀원별 주력 캐릭터 1~3개를 전달해주세요." },
+      { status: 400, headers: NO_STORE_HEADERS }
+    );
+  }
+
+  try {
+    const rows = await fetchTeamComboRows(request.nextUrl.origin, pools);
+    const results = sortTrioWeaponCombos(
+      mergeApiRowsByComboId(rows).filter((combo) => comboMatchesTeamPools(combo, pools)),
+      "recommended"
+    );
+    const pickRankings = buildPickRankings(results, pools[0]);
+
+    return NextResponse.json({ pickRankings, results }, { headers: NO_STORE_HEADERS });
+  } catch (err) {
+    console.error("[multi-search/team-combos] 예외:", err);
+    return NextResponse.json(
+      { error: "팀 조합 추천 데이터를 불러오지 못했습니다." },
+      { status: 500, headers: NO_STORE_HEADERS }
+    );
+  }
+}

--- a/frontend/src/app/api/multi-search/team-combos/route.ts
+++ b/frontend/src/app/api/multi-search/team-combos/route.ts
@@ -7,6 +7,7 @@ import {
   type TrioWeaponMember,
   type TrioWeaponCombo,
 } from "@/components/features/trio-lab/types";
+import { isMultiSearchEnabled } from "@/lib/featureFlags";
 
 const TEAM_SIZE = 3;
 const MAX_POOL_SIZE = 3;
@@ -195,6 +196,10 @@ function buildPickRankings(combos: TrioWeaponCombo[], myPool: number[]): PickRan
 }
 
 export async function POST(request: NextRequest) {
+  if (!isMultiSearchEnabled()) {
+    return NextResponse.json({ error: "not_found" }, { status: 404, headers: NO_STORE_HEADERS });
+  }
+
   let body: TeamCombosBody;
   try {
     body = (await request.json()) as TeamCombosBody;

--- a/frontend/src/app/api/multi-search/team-combos/route.ts
+++ b/frontend/src/app/api/multi-search/team-combos/route.ts
@@ -1,10 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import {
   mergeApiRowsByComboId,
-  recommendationScore,
   sortTrioWeaponCombos,
   type ApiTrioWeaponRow,
-  type TrioWeaponMember,
   type TrioWeaponCombo,
 } from "@/components/features/trio-lab/types";
 import { isMultiSearchEnabled } from "@/lib/featureFlags";
@@ -18,16 +16,6 @@ const NO_STORE_HEADERS = {
 
 interface TeamCombosBody {
   pools?: unknown;
-}
-
-interface PickRanking {
-  character: number;
-  weapon: number;
-  totalGames: number;
-  winRate: number;
-  averageRP: number;
-  averageRank: number;
-  bestComboIds: string[];
 }
 
 function normalizePools(pools: unknown): number[][] | null {
@@ -97,6 +85,10 @@ async function fetchTeamComboRows(origin: string, pools: number[][]): Promise<Ap
             })
               .then((response) => (response.ok ? response.json() : { results: [] }))
               .then((payload: { results?: ApiTrioWeaponRow[] }) => payload.results ?? [])
+              .catch((err) => {
+                console.error(`[multi-search/team-combos] stats fetch failed ${pairKey}:`, err);
+                return [];
+              })
           );
         }
       }
@@ -105,94 +97,6 @@ async function fetchTeamComboRows(origin: string, pools: number[][]): Promise<Ap
 
   const settled = await Promise.all(requests);
   return settled.flat();
-}
-
-function findMyMember(combo: TrioWeaponCombo, myPool: number[]): TrioWeaponMember | null {
-  return combo.members.find((member) => myPool.includes(member.character)) ?? null;
-}
-
-function buildPickRankings(combos: TrioWeaponCombo[], myPool: number[]): PickRanking[] {
-  const rankings = new Map<
-    string,
-    PickRanking & { rpSum: number; rankSum: number; winSum: number }
-  >();
-
-  for (const combo of combos) {
-    const myMember = findMyMember(combo, myPool);
-    if (!myMember) continue;
-
-    const key = `${myMember.character}:${myMember.weapon}`;
-    const current = rankings.get(key) ?? {
-      character: myMember.character,
-      weapon: myMember.weapon,
-      totalGames: 0,
-      winRate: 0,
-      averageRP: 0,
-      averageRank: 0,
-      bestComboIds: [],
-      rpSum: 0,
-      rankSum: 0,
-      winSum: 0,
-    };
-
-    current.totalGames += combo.totalGames;
-    current.rpSum += combo.averageRP * combo.totalGames;
-    current.rankSum += combo.averageRank * combo.totalGames;
-    current.winSum += combo.winRate * combo.totalGames;
-    rankings.set(key, current);
-  }
-
-  return Array.from(rankings.values())
-    .map((ranking) => {
-      const bestComboIds = combos
-        .filter((combo) =>
-          combo.members.some(
-            (member) => member.character === ranking.character && member.weapon === ranking.weapon
-          )
-        )
-        .sort(
-          (a, b) =>
-            b.averageRP - a.averageRP || b.totalGames - a.totalGames || b.winRate - a.winRate
-        )
-        .map((combo) => combo.id);
-
-      return {
-        character: ranking.character,
-        weapon: ranking.weapon,
-        totalGames: ranking.totalGames,
-        winRate: ranking.totalGames > 0 ? ranking.winSum / ranking.totalGames : 0,
-        averageRP: ranking.totalGames > 0 ? ranking.rpSum / ranking.totalGames : 0,
-        averageRank: ranking.totalGames > 0 ? ranking.rankSum / ranking.totalGames : 0,
-        bestComboIds,
-      };
-    })
-    .sort(
-      (a, b) =>
-        recommendationScore({
-          id: `${b.character}-${b.weapon}`,
-          members: [
-            { character: b.character, weapon: b.weapon, mainCore: null },
-            { character: 0, weapon: 0, mainCore: null },
-            { character: 0, weapon: 0, mainCore: null },
-          ],
-          totalGames: b.totalGames,
-          winRate: b.winRate,
-          averageRP: b.averageRP,
-          averageRank: b.averageRank,
-        }) -
-        recommendationScore({
-          id: `${a.character}-${a.weapon}`,
-          members: [
-            { character: a.character, weapon: a.weapon, mainCore: null },
-            { character: 0, weapon: 0, mainCore: null },
-            { character: 0, weapon: 0, mainCore: null },
-          ],
-          totalGames: a.totalGames,
-          winRate: a.winRate,
-          averageRP: a.averageRP,
-          averageRank: a.averageRank,
-        })
-    );
 }
 
 export async function POST(request: NextRequest) {
@@ -224,9 +128,8 @@ export async function POST(request: NextRequest) {
       mergeApiRowsByComboId(rows).filter((combo) => comboMatchesTeamPools(combo, pools)),
       "recommended"
     );
-    const pickRankings = buildPickRankings(results, pools[0]);
 
-    return NextResponse.json({ pickRankings, results }, { headers: NO_STORE_HEADERS });
+    return NextResponse.json({ results }, { headers: NO_STORE_HEADERS });
   } catch (err) {
     console.error("[multi-search/team-combos] 예외:", err);
     return NextResponse.json(

--- a/frontend/src/components/features/multi-search/MultiSearchClient.tsx
+++ b/frontend/src/components/features/multi-search/MultiSearchClient.tsx
@@ -1,10 +1,21 @@
 "use client";
 
-import { AlertTriangle, Loader2, Search, Trophy, Users } from "lucide-react";
-import { FormEvent, useMemo, useState } from "react";
+import { AlertTriangle, Loader2, Search, Swords, Trophy, Users } from "lucide-react";
+import Image from "next/image";
+import { FormEvent, useEffect, useMemo, useState } from "react";
 import { getFallbackMap } from "@/components/features/synergy/constants";
+import { getCharacterWeaponOptions } from "@/components/features/trio-lab/searchRequests";
+import {
+  comboTier,
+  characterDisplayName,
+  weaponDisplayName,
+  type TrioWeaponCombo,
+} from "@/components/features/trio-lab/types";
+import { buildTrioLabDetailHref } from "@/components/features/trio-lab/urlState";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Link } from "@/i18n/navigation";
+import { getCharacterMiniWebpUrl } from "@/lib/characterMap";
 import { cn } from "@/lib/utils";
 
 interface MultiSearchResponse {
@@ -43,91 +54,291 @@ interface PlayerResult {
   reason?: string;
 }
 
-const EMPTY_INPUTS = ["", "", ""];
+interface PickRanking {
+  character: number;
+  weapon: number;
+  totalGames: number;
+  winRate: number;
+  averageRP: number;
+  averageRank: number;
+  bestComboIds: string[];
+}
+
+interface TeamCombosResponse {
+  pickRankings: PickRanking[];
+  results: TrioWeaponCombo[];
+}
+
+const TOP_CHARACTER_LIMIT = 3;
+const MY_NICKNAME_STORAGE_KEY = "ermeta:multi-search:my-nickname";
 
 export function MultiSearchClient() {
-  const [inputs, setInputs] = useState<string[]>(EMPTY_INPUTS);
+  const [myNickname, setMyNickname] = useState("");
+  const [teammateInput, setTeammateInput] = useState("");
+  const [myProfile, setMyProfile] = useState<PlayerResult | null>(null);
+  const [myWeaponFilters, setMyWeaponFilters] = useState<Record<number, number>>({});
   const [data, setData] = useState<MultiSearchResponse | null>(null);
+  const [teamCombos, setTeamCombos] = useState<TrioWeaponCombo[]>([]);
+  const [pickRankings, setPickRankings] = useState<PickRanking[]>([]);
+  const [teammateCharacterFilters, setTeammateCharacterFilters] = useState<Array<number | null>>([
+    null,
+    null,
+  ]);
+  const [isComboLoading, setIsComboLoading] = useState(false);
+  const [comboError, setComboError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isMyLoading, setIsMyLoading] = useState(false);
+  const [isTeamLoading, setIsTeamLoading] = useState(false);
   const characterNames = useMemo(() => getFallbackMap(), []);
 
-  const normalizedNicknames = useMemo(
-    () => inputs.map((value) => value.trim()).filter(Boolean),
-    [inputs]
-  );
+  const teammateNicknames = useMemo(() => {
+    return teammateInput
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean)
+      .slice(0, 2);
+  }, [teammateInput]);
 
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+  useEffect(() => {
+    try {
+      setMyNickname(localStorage.getItem(MY_NICKNAME_STORAGE_KEY) ?? "");
+    } catch {
+      /* localStorage unavailable */
+    }
+  }, []);
+
+  useEffect(() => {
+    try {
+      const trimmed = myNickname.trim();
+      if (trimmed) {
+        localStorage.setItem(MY_NICKNAME_STORAGE_KEY, trimmed);
+      } else {
+        localStorage.removeItem(MY_NICKNAME_STORAGE_KEY);
+      }
+    } catch {
+      /* localStorage unavailable */
+    }
+  }, [myNickname]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadTeamRecommendations() {
+      const players = data?.results.filter((result) => result.status === "ok") ?? [];
+      if (players.length !== 3) {
+        setTeamCombos([]);
+        setPickRankings([]);
+        setComboError(null);
+        setIsComboLoading(false);
+        return;
+      }
+
+      const pools = players.map((player) => getTopCharacterCodes(player));
+      if (pools.some((pool) => pool.length === 0)) {
+        setTeamCombos([]);
+        setPickRankings([]);
+        setComboError("팀원별 주력 캐릭터 표본이 부족해 조합을 추천할 수 없습니다.");
+        setIsComboLoading(false);
+        return;
+      }
+
+      setIsComboLoading(true);
+      setComboError(null);
+
+      try {
+        const recommendations = await fetchTeamCombos(pools);
+        if (cancelled) return;
+
+        setTeamCombos(recommendations.results);
+        setPickRankings(recommendations.pickRankings);
+        setComboError(
+          recommendations.results.length === 0 ? "조건에 맞는 조합 실험실 표본이 없습니다." : null
+        );
+      } catch {
+        if (!cancelled) {
+          setTeamCombos([]);
+          setPickRankings([]);
+          setComboError("팀 조합 추천 데이터를 불러오지 못했습니다.");
+        }
+      } finally {
+        if (!cancelled) setIsComboLoading(false);
+      }
+    }
+
+    void loadTeamRecommendations();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [data]);
+
+  async function handleMySubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (normalizedNicknames.length === 0) {
-      setError("검색할 팀원 닉네임을 입력해주세요.");
+    if (!myNickname.trim()) {
+      setError("내 닉네임을 입력해주세요.");
+      setMyProfile(null);
       setData(null);
+      setTeamCombos([]);
+      setPickRankings([]);
       return;
     }
 
-    setIsLoading(true);
+    setIsMyLoading(true);
     setError(null);
+    setComboError(null);
 
     try {
-      const response = await fetch("/api/multi-search/players", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ nicknames: normalizedNicknames }),
-      });
-
-      const payload = await response.json();
-      if (!response.ok) {
-        const message = Array.isArray(payload?.message)
-          ? payload.message.join(" ")
-          : payload?.message || "멀티서치 요청에 실패했습니다.";
-        throw new Error(message);
+      const payload = await fetchPlayers([myNickname.trim()]);
+      const profile = payload.results[0] ?? null;
+      if (!profile || profile.status !== "ok") {
+        throw new Error("내 시즌 39 랭크 정보를 찾지 못했습니다.");
       }
 
-      setData(payload as MultiSearchResponse);
-    } catch (err) {
+      setMyProfile(profile);
       setData(null);
-      setError(err instanceof Error ? err.message : "멀티서치 요청에 실패했습니다.");
+      setTeamCombos([]);
+      setPickRankings([]);
+      setTeammateCharacterFilters([null, null]);
+      setMyWeaponFilters(buildDefaultWeaponFilters(profile));
+    } catch (err) {
+      setMyProfile(null);
+      setData(null);
+      setTeamCombos([]);
+      setPickRankings([]);
+      setTeammateCharacterFilters([null, null]);
+      setMyWeaponFilters({});
+      setError(err instanceof Error ? err.message : "내 정보 검색에 실패했습니다.");
     } finally {
-      setIsLoading(false);
+      setIsMyLoading(false);
     }
   }
 
-  function updateInput(index: number, value: string) {
-    setInputs((current) => current.map((item, itemIndex) => (itemIndex === index ? value : item)));
+  async function handleTeamSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!myProfile || myProfile.status !== "ok") {
+      setError("먼저 내 정보를 검색해주세요.");
+      return;
+    }
+    if (teammateNicknames.length < 2) {
+      setError("팀원 닉네임 2명을 쉼표로 구분해 입력해주세요.");
+      setData(null);
+      setTeamCombos([]);
+      setPickRankings([]);
+      setTeammateCharacterFilters([null, null]);
+      return;
+    }
+
+    setIsTeamLoading(true);
+    setError(null);
+
+    try {
+      const teammateData = await fetchPlayers(teammateNicknames);
+      setData({
+        ...teammateData,
+        results: [myProfile, ...teammateData.results],
+      });
+    } catch (err) {
+      setData(null);
+      setTeamCombos([]);
+      setPickRankings([]);
+      setTeammateCharacterFilters([null, null]);
+      setError(err instanceof Error ? err.message : "멀티서치 요청에 실패했습니다.");
+    } finally {
+      setIsTeamLoading(false);
+    }
+  }
+
+  function updateMyWeaponFilter(characterCode: number, weaponCode: number) {
+    setMyWeaponFilters((current) => {
+      const next = { ...current };
+      if (weaponCode > 0) next[characterCode] = weaponCode;
+      else delete next[characterCode];
+      return next;
+    });
+  }
+
+  function toggleTeammateCharacterFilter(teammateIndex: number, characterCode: number) {
+    setTeammateCharacterFilters((current) =>
+      current.map((selected, index) =>
+        index === teammateIndex ? (selected === characterCode ? null : characterCode) : selected
+      )
+    );
   }
 
   return (
     <div className="flex flex-col gap-5">
       <form
-        onSubmit={handleSubmit}
-        className="rounded-[22px] border border-[var(--color-border)] bg-[rgba(15,23,42,0.72)] p-4 shadow-[0_20px_48px_-36px_rgba(0,0,0,0.68)] sm:p-5"
+        onSubmit={handleMySubmit}
+        className="rounded-2xl border border-[var(--color-border)] bg-[rgba(15,23,42,0.72)] p-3 shadow-[0_20px_48px_-36px_rgba(0,0,0,0.68)] sm:p-4"
       >
-        <div className="grid gap-3 md:grid-cols-[1fr_1fr_1fr_auto]">
-          {inputs.map((value, index) => (
-            <label key={index} className="flex min-w-0 flex-col gap-2">
-              <span className="text-xs font-semibold text-[var(--color-muted-foreground)]">
-                팀원 {index + 1}
-              </span>
-              <input
-                value={value}
-                onChange={(event) => updateInput(index, event.target.value)}
-                maxLength={16}
-                autoComplete="off"
-                placeholder="닉네임"
-                className="h-11 rounded-xl border border-[var(--color-border)] bg-[rgba(8,13,25,0.86)] px-3 text-sm font-semibold text-[var(--color-foreground)] outline-none transition focus:border-[rgba(96,165,250,0.52)] focus:ring-2 focus:ring-[rgba(96,165,250,0.16)]"
-              />
-            </label>
-          ))}
-          <Button type="submit" size="lg" disabled={isLoading} className="mt-auto h-11 md:min-w-28">
-            {isLoading ? (
+        <div className="grid gap-2 lg:grid-cols-[minmax(180px,0.45fr)_auto]">
+          <label className="min-w-0">
+            <span className="sr-only">내 닉네임</span>
+            <input
+              value={myNickname}
+              onChange={(event) => setMyNickname(event.target.value)}
+              maxLength={16}
+              autoComplete="nickname"
+              placeholder="내 닉네임"
+              className="h-10 w-full min-w-0 rounded-xl border border-[var(--color-border)] bg-[rgba(8,13,25,0.86)] px-3 text-sm font-semibold text-[var(--color-foreground)] outline-none transition focus:border-[rgba(96,165,250,0.52)] focus:ring-2 focus:ring-[rgba(96,165,250,0.16)]"
+            />
+          </label>
+          <Button type="submit" size="lg" disabled={isMyLoading} className="h-10 md:min-w-28">
+            {isMyLoading ? (
               <Loader2 className="h-4 w-4 animate-spin" />
             ) : (
               <Search className="h-4 w-4" />
             )}
-            검색
+            내 정보 검색
           </Button>
         </div>
-        {error && (
+        {error && !myProfile && (
+          <div className="mt-4 flex items-start gap-2 rounded-xl border border-[rgba(248,113,113,0.28)] bg-[rgba(127,29,29,0.18)] px-3 py-2 text-sm text-[var(--color-danger)]">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+      </form>
+
+      {myProfile && (
+        <MyProfileSetupCard
+          result={myProfile}
+          weaponFilters={myWeaponFilters}
+          onWeaponChange={updateMyWeaponFilter}
+          getCharacterName={(code) => characterNames.get(code) ?? `#${code}`}
+        />
+      )}
+
+      <form
+        onSubmit={handleTeamSubmit}
+        className="rounded-2xl border border-[var(--color-border)] bg-[rgba(15,23,42,0.58)] p-3 shadow-[0_20px_48px_-36px_rgba(0,0,0,0.58)] sm:p-4"
+      >
+        <div className="grid gap-2 lg:grid-cols-[1fr_auto]">
+          <label className="min-w-0">
+            <span className="sr-only">팀원 닉네임</span>
+            <input
+              value={teammateInput}
+              onChange={(event) => setTeammateInput(event.target.value)}
+              autoComplete="off"
+              placeholder="팀원 2명 닉네임, 쉼표로 구분"
+              className="h-10 w-full min-w-0 rounded-xl border border-[var(--color-border)] bg-[rgba(8,13,25,0.86)] px-3 text-sm font-semibold text-[var(--color-foreground)] outline-none transition focus:border-[rgba(96,165,250,0.52)] focus:ring-2 focus:ring-[rgba(96,165,250,0.16)]"
+            />
+          </label>
+          <Button
+            type="submit"
+            size="lg"
+            disabled={isTeamLoading || !myProfile}
+            className="h-10 md:min-w-24"
+          >
+            {isTeamLoading ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Search className="h-4 w-4" />
+            )}
+            팀원 검색
+          </Button>
+        </div>
+        {error && myProfile && (
           <div className="mt-4 flex items-start gap-2 rounded-xl border border-[rgba(248,113,113,0.28)] bg-[rgba(127,29,29,0.18)] px-3 py-2 text-sm text-[var(--color-danger)]">
             <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
             <span>{error}</span>
@@ -136,15 +347,32 @@ export function MultiSearchClient() {
       </form>
 
       {data && (
-        <section className="grid gap-4 lg:grid-cols-3">
-          {data.results.map((result) => (
+        <section className="grid gap-3 lg:grid-cols-3">
+          {data.results.map((result, index) => (
             <PlayerCard
               key={result.input}
               result={result}
+              selectedCharacter={index > 0 ? (teammateCharacterFilters[index - 1] ?? null) : null}
+              onToggleCharacter={
+                index > 0
+                  ? (characterCode) => toggleTeammateCharacterFilter(index - 1, characterCode)
+                  : undefined
+              }
               getCharacterName={(code) => characterNames.get(code) ?? `#${code}`}
             />
           ))}
         </section>
+      )}
+
+      {data && (
+        <TeamComboRecommendations
+          combos={teamCombos}
+          players={data.results}
+          myWeaponFilters={myWeaponFilters}
+          teammateCharacterFilters={teammateCharacterFilters}
+          loading={isComboLoading}
+          error={comboError}
+        />
       )}
     </div>
   );
@@ -152,21 +380,25 @@ export function MultiSearchClient() {
 
 function PlayerCard({
   result,
+  selectedCharacter,
+  onToggleCharacter,
   getCharacterName,
 }: {
   result: PlayerResult;
+  selectedCharacter: number | null;
+  onToggleCharacter?: (characterCode: number) => void;
   getCharacterName: (code: number) => string;
 }) {
   if (result.status !== "ok") {
     return (
-      <Card className="min-h-56">
-        <CardContent className="flex h-full flex-col justify-between gap-5 p-5">
+      <Card>
+        <CardContent className="flex h-full flex-col gap-3 p-3">
           <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-xl border border-[rgba(248,113,113,0.24)] bg-[rgba(127,29,29,0.18)] text-[var(--color-danger)]">
-              <AlertTriangle className="h-5 w-5" />
+            <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-[rgba(248,113,113,0.24)] bg-[rgba(127,29,29,0.18)] text-[var(--color-danger)]">
+              <AlertTriangle className="h-4 w-4" />
             </div>
             <div className="min-w-0">
-              <p className="truncate text-base font-bold text-[var(--color-foreground)]">
+              <p className="truncate text-sm font-bold text-[var(--color-foreground)]">
                 {result.input}
               </p>
               <p className="text-xs font-semibold text-[var(--color-muted-foreground)]">
@@ -174,8 +406,8 @@ function PlayerCard({
               </p>
             </div>
           </div>
-          <p className="text-sm leading-6 text-[var(--color-muted-foreground)]">
-            닉네임을 다시 확인하거나 시즌 39 랭크 기록이 있는 팀원을 검색해주세요.
+          <p className="text-xs leading-5 text-[var(--color-muted-foreground)]">
+            닉네임 또는 시즌 39 랭크 기록을 확인해주세요.
           </p>
         </CardContent>
       </Card>
@@ -184,64 +416,161 @@ function PlayerCard({
 
   return (
     <Card className="overflow-hidden">
-      <CardContent className="flex flex-col gap-5 p-5">
-        <div className="flex items-start justify-between gap-3">
+      <CardContent className="flex flex-col gap-3 p-3">
+        <div className="flex items-center justify-between gap-3">
           <div className="min-w-0">
-            <p className="truncate text-lg font-black text-[var(--color-foreground)]">
+            <p className="truncate text-base font-black text-[var(--color-foreground)]">
               {result.nickname}
             </p>
-            <p className="mt-1 text-xs font-semibold text-[var(--color-muted-foreground)]">
-              시즌 {result.seasonId} · 스쿼드 랭크
+            <p className="text-xs font-semibold text-[var(--color-muted-foreground)]">
+              #{formatNumber(result.rank)} · MMR {formatNumber(result.mmr)}
             </p>
           </div>
-          <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-[rgba(96,165,250,0.26)] bg-[rgba(96,165,250,0.12)] text-[var(--color-primary)]">
-            <Trophy className="h-5 w-5" />
+          <div className="flex h-9 w-9 items-center justify-center rounded-lg border border-[rgba(96,165,250,0.26)] bg-[rgba(96,165,250,0.12)] text-[var(--color-primary)]">
+            <Trophy className="h-4 w-4" />
           </div>
         </div>
 
-        <div className="grid grid-cols-2 gap-3">
-          <Metric label="랭크" value={formatRank(result.rank, result.rankSize)} strong />
-          <Metric label="MMR" value={formatNumber(result.mmr)} strong />
+        <div className="grid grid-cols-3 gap-2">
           <Metric label="승률" value={`${formatNumber(result.winRate)}%`} />
           <Metric label="Top 3" value={`${formatNumber(result.top3Rate)}%`} />
-          <Metric label="평균 순위" value={formatNumber(result.averageRank)} />
           <Metric label="평균 킬" value={formatNumber(result.averageKills)} />
         </div>
 
         <div className="flex flex-col gap-2">
-          <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-[var(--color-muted-foreground)]">
+          <div className="flex items-center gap-2 text-[11px] font-bold uppercase tracking-wider text-[var(--color-muted-foreground)]">
             <Users className="h-3.5 w-3.5" />
             주력 캐릭터
           </div>
-          <div className="flex flex-col gap-2">
-            {(result.topCharacters ?? []).map((character) => (
-              <div
-                key={character.characterCode}
-                className="grid grid-cols-[1fr_auto] gap-3 rounded-xl border border-[var(--color-border)] bg-[rgba(255,255,255,0.03)] px-3 py-2"
-              >
-                <div className="min-w-0">
-                  <p className="truncate text-sm font-bold text-[var(--color-foreground)]">
-                    {getCharacterName(character.characterCode)}
-                  </p>
-                  <p className="text-xs text-[var(--color-muted-foreground)]">
-                    {character.totalGames}게임 · 승률 {formatNumber(character.winRate)}%
-                  </p>
-                </div>
+          <div className="grid gap-2">
+            {(result.topCharacters ?? []).slice(0, TOP_CHARACTER_LIMIT).map((character) => {
+              return (
                 <div
+                  key={character.characterCode}
                   className={cn(
-                    "text-right text-xs font-semibold",
-                    character.top3Rate >= 50
-                      ? "text-[var(--color-stat-up)]"
-                      : "text-[var(--color-muted-foreground)]"
+                    "grid gap-2 rounded-lg border px-2.5 py-1.5 transition",
+                    "grid-cols-[1fr_auto]",
+                    selectedCharacter === character.characterCode
+                      ? "border-[rgba(96,165,250,0.52)] bg-[rgba(96,165,250,0.14)]"
+                      : "border-[var(--color-border)] bg-[rgba(255,255,255,0.03)]",
+                    onToggleCharacter &&
+                      "hover:border-[rgba(96,165,250,0.32)] hover:bg-[rgba(96,165,250,0.06)]"
                   )}
                 >
-                  Top 3
-                  <br />
-                  {formatNumber(character.top3Rate)}%
+                  <button
+                    type="button"
+                    disabled={!onToggleCharacter}
+                    onClick={() => onToggleCharacter?.(character.characterCode)}
+                    className="min-w-0 text-left disabled:cursor-default"
+                  >
+                    <p className="truncate text-xs font-bold text-[var(--color-foreground)]">
+                      {getCharacterName(character.characterCode)}
+                    </p>
+                    <p className="text-[11px] text-[var(--color-muted-foreground)]">
+                      {character.totalGames}게임 · 승률 {formatNumber(character.winRate)}%
+                    </p>
+                  </button>
+                  <button
+                    type="button"
+                    disabled={!onToggleCharacter}
+                    onClick={() => onToggleCharacter?.(character.characterCode)}
+                    className={cn(
+                      "text-right text-xs font-semibold",
+                      character.top3Rate >= 50
+                        ? "text-[var(--color-stat-up)]"
+                        : "text-[var(--color-muted-foreground)]"
+                    )}
+                  >
+                    T3 {formatNumber(character.top3Rate)}%
+                  </button>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function MyProfileSetupCard({
+  result,
+  weaponFilters,
+  onWeaponChange,
+  getCharacterName,
+}: {
+  result: PlayerResult;
+  weaponFilters: Record<number, number>;
+  onWeaponChange: (characterCode: number, weaponCode: number) => void;
+  getCharacterName: (code: number) => string;
+}) {
+  if (result.status !== "ok") return null;
+
+  return (
+    <Card className="overflow-hidden border-[rgba(96,165,250,0.28)]">
+      <CardContent className="flex flex-col gap-3 p-3 sm:p-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="min-w-0">
+            <p className="text-xs font-bold uppercase tracking-wider text-[var(--color-muted-foreground)]">
+              내 캐릭터 정보
+            </p>
+            <h2 className="mt-1 truncate text-lg font-black text-[var(--color-foreground)]">
+              {result.nickname}
+            </h2>
+          </div>
+          <div className="grid grid-cols-3 gap-2 text-center">
+            <Metric label="승률" value={`${formatNumber(result.winRate)}%`} />
+            <Metric label="Top 3" value={`${formatNumber(result.top3Rate)}%`} />
+            <Metric label="평균 킬" value={formatNumber(result.averageKills)} />
+          </div>
+        </div>
+
+        <div className="grid gap-2 lg:grid-cols-3">
+          {(result.topCharacters ?? []).slice(0, TOP_CHARACTER_LIMIT).map((character) => {
+            const weaponOptions = getCharacterWeaponOptions(character.characterCode);
+            return (
+              <div
+                key={character.characterCode}
+                className="grid gap-2 rounded-lg border border-[var(--color-border)] bg-[rgba(255,255,255,0.035)] p-2.5"
+              >
+                <div className="grid grid-cols-[36px_1fr] items-center gap-2">
+                  <div className="relative h-9 w-9 overflow-hidden rounded-lg border border-[rgba(255,255,255,0.08)] bg-[var(--color-surface-2)]">
+                    <Image
+                      src={getCharacterMiniWebpUrl(character.characterCode)}
+                      alt={getCharacterName(character.characterCode)}
+                      fill
+                      sizes="36px"
+                      className="object-cover"
+                      unoptimized
+                    />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-black text-[var(--color-foreground)]">
+                      {getCharacterName(character.characterCode)}
+                    </p>
+                    <p className="truncate text-xs text-[var(--color-muted-foreground)]">
+                      {character.totalGames}게임 · 승률 {formatNumber(character.winRate)}%
+                    </p>
+                  </div>
+                </div>
+                <select
+                  value={weaponFilters[character.characterCode] ?? 0}
+                  onChange={(event) =>
+                    onWeaponChange(character.characterCode, Number(event.target.value))
+                  }
+                  className="h-9 rounded-lg border border-[var(--color-border)] bg-[rgba(8,13,25,0.88)] px-2 text-xs font-semibold text-[var(--color-foreground)] outline-none"
+                  aria-label={`${getCharacterName(character.characterCode)} 무기군`}
+                >
+                  <option value={0}>전체 무기</option>
+                  {weaponOptions.map((weapon) => (
+                    <option key={weapon.weaponCode} value={weapon.weaponCode}>
+                      {weapon.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            );
+          })}
         </div>
       </CardContent>
     </Card>
@@ -258,7 +587,7 @@ function Metric({
   strong?: boolean;
 }) {
   return (
-    <div className="rounded-xl border border-[var(--color-border)] bg-[rgba(255,255,255,0.03)] px-3 py-2">
+    <div className="rounded-lg border border-[var(--color-border)] bg-[rgba(255,255,255,0.03)] px-2 py-1.5">
       <p className="text-[11px] font-semibold text-[var(--color-muted-foreground)]">{label}</p>
       <p
         className={cn(
@@ -283,8 +612,404 @@ function formatNumber(value: number | undefined) {
   return new Intl.NumberFormat("ko-KR", { maximumFractionDigits: 2 }).format(value);
 }
 
-function formatRank(rank: number | undefined, rankSize: number | undefined) {
-  if (!rank) return "-";
-  if (!rankSize) return `#${formatNumber(rank)}`;
-  return `#${formatNumber(rank)} / ${formatNumber(rankSize)}`;
+function getTopCharacterCodes(player: PlayerResult): number[] {
+  return Array.from(
+    new Set(
+      (player.topCharacters ?? [])
+        .slice(0, TOP_CHARACTER_LIMIT)
+        .map((character) => character.characterCode)
+        .filter((code) => Number.isFinite(code) && code > 0)
+    )
+  );
+}
+
+function buildDefaultWeaponFilters(player: PlayerResult): Record<number, number> {
+  return Object.fromEntries(
+    getTopCharacterCodes(player)
+      .map((characterCode) => {
+        const options = getCharacterWeaponOptions(characterCode);
+        const weapon = options.find((option) => option.isDefault) ?? options[0];
+        return weapon ? [characterCode, weapon.weaponCode] : null;
+      })
+      .filter((entry): entry is [number, number] => entry != null)
+  );
+}
+
+async function fetchPlayers(nicknames: string[]): Promise<MultiSearchResponse> {
+  const response = await fetch("/api/multi-search/players", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ nicknames }),
+  });
+
+  const payload = await response.json();
+  if (!response.ok) {
+    const message = Array.isArray(payload?.message)
+      ? payload.message.join(" ")
+      : payload?.message || "멀티서치 요청에 실패했습니다.";
+    throw new Error(message);
+  }
+
+  return payload as MultiSearchResponse;
+}
+
+async function fetchTeamCombos(pools: number[][]): Promise<TeamCombosResponse> {
+  const response = await fetch("/api/multi-search/team-combos", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ pools }),
+    cache: "no-store",
+  });
+
+  if (!response.ok) throw new Error("team_combo_failed");
+
+  const payload = (await response.json()) as Partial<TeamCombosResponse>;
+  return {
+    pickRankings: payload.pickRankings ?? [],
+    results: payload.results ?? [],
+  };
+}
+
+function comboDetailHref(combo: TrioWeaponCombo): string {
+  const pool = combo.members.map((member) => member.character);
+  const weaponFilters = Object.fromEntries(
+    combo.members.map((member) => [member.character, member.weapon])
+  ) as Record<number, number>;
+
+  return buildTrioLabDetailHref(combo.id, {
+    pool,
+    weaponFilters,
+    sort: "recommended",
+    search: "",
+  });
+}
+
+function memberDisplayName(member: TrioWeaponCombo["members"][number]): string {
+  return `${characterDisplayName(member.character)} ${weaponDisplayName(member.weapon)}`;
+}
+
+function TeamComboRecommendations({
+  combos,
+  players,
+  myWeaponFilters,
+  teammateCharacterFilters,
+  loading,
+  error,
+}: {
+  combos: TrioWeaponCombo[];
+  players: PlayerResult[];
+  myWeaponFilters: Record<number, number>;
+  teammateCharacterFilters: Array<number | null>;
+  loading: boolean;
+  error: string | null;
+}) {
+  const isReady = players.filter((player) => player.status === "ok").length === 3;
+  const activeWeaponFilterCount = Object.keys(myWeaponFilters).length;
+  const recommendedCombos = useMemo(
+    () =>
+      buildBestCombosByTeammatePicks(combos, players, myWeaponFilters, teammateCharacterFilters),
+    [combos, players, myWeaponFilters, teammateCharacterFilters]
+  );
+  const recommendationTitle =
+    activeWeaponFilterCount > 0
+      ? "팀원 후보 조합별 최적 내 픽"
+      : "팀원 후보군에 맞는 내 캐릭터/무기";
+
+  if (!isReady) {
+    return null;
+  }
+
+  return (
+    <section className="flex flex-col gap-3 rounded-2xl border border-[var(--color-border)] bg-[rgba(15,23,42,0.58)] p-3 sm:p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-[var(--color-muted-foreground)]">
+            <Swords className="h-4 w-4" />내 픽 추천
+          </div>
+          <h2 className="mt-1 text-lg font-black text-[var(--color-foreground)]">
+            {recommendationTitle}
+          </h2>
+          <p className="mt-1 max-w-3xl text-xs leading-5 text-[var(--color-muted-foreground)]">
+            팀원 2명의 주력 캐릭터 후보 조합마다 내 캐릭터/무기군 조건에서 가장 RP가 높은 픽을
+            하나씩 고르고, 그 조합들을 RP 기준으로 정렬합니다.
+          </p>
+        </div>
+        {loading && (
+          <span className="inline-flex items-center gap-2 rounded-xl border border-[var(--color-border)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-xs font-semibold text-[var(--color-muted-foreground)]">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            추천 계산 중
+          </span>
+        )}
+      </div>
+
+      {error && !loading && (
+        <div className="flex items-start gap-2 rounded-xl border border-[rgba(248,113,113,0.24)] bg-[rgba(127,29,29,0.16)] px-3 py-2 text-sm text-[var(--color-danger)]">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {!loading && !error && recommendedCombos.length === 0 && combos.length > 0 && (
+        <div className="rounded-xl border border-[var(--color-border)] bg-[rgba(255,255,255,0.035)] px-3 py-2 text-sm text-[var(--color-muted-foreground)]">
+          설정한 캐릭터별 무기군과 맞는 표본이 없습니다.
+        </div>
+      )}
+
+      {!loading && !error && recommendedCombos.length > 0 && (
+        <div className="grid gap-2 lg:grid-cols-3">
+          {recommendedCombos.map((recommendation, index) => (
+            <MyPickComboCard
+              key={recommendation.key}
+              recommendation={recommendation}
+              rank={index + 1}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+type OrderedComboMembers = [
+  TrioWeaponCombo["members"][number],
+  TrioWeaponCombo["members"][number],
+  TrioWeaponCombo["members"][number],
+];
+
+interface OrderedComboRecommendation {
+  key: string;
+  myMember: TrioWeaponCombo["members"][number];
+  combos: Array<{
+    combo: TrioWeaponCombo;
+    members: OrderedComboMembers;
+  }>;
+}
+
+function buildBestCombosByTeammatePicks(
+  combos: TrioWeaponCombo[],
+  players: PlayerResult[],
+  myWeaponFilters: Record<number, number>,
+  teammateCharacterFilters: Array<number | null>
+): OrderedComboRecommendation[] {
+  const pools = players.map((player) => getTopCharacterCodes(player));
+  if (pools.length !== 3 || pools.some((pool) => pool.length === 0)) return [];
+
+  const bestByTeammatePick = new Map<
+    string,
+    {
+      combo: TrioWeaponCombo;
+      members: OrderedComboMembers;
+    }
+  >();
+
+  for (const combo of combos) {
+    const members = orderComboMembersByPlayerPools(combo, pools);
+    if (!members) continue;
+
+    const myMember = members[0];
+    const selectedWeapon = myWeaponFilters[myMember.character];
+    if (selectedWeapon > 0 && myMember.weapon !== selectedWeapon) continue;
+    if (
+      teammateCharacterFilters[0] != null &&
+      members[1].character !== teammateCharacterFilters[0]
+    ) {
+      continue;
+    }
+    if (
+      teammateCharacterFilters[1] != null &&
+      members[2].character !== teammateCharacterFilters[1]
+    ) {
+      continue;
+    }
+
+    const teammateKey = members
+      .slice(1)
+      .map((member) => `${member.character}:${member.weapon}`)
+      .join("|");
+    const current = bestByTeammatePick.get(teammateKey);
+
+    if (
+      !current ||
+      combo.averageRP > current.combo.averageRP ||
+      (combo.averageRP === current.combo.averageRP &&
+        combo.totalGames > current.combo.totalGames) ||
+      (combo.averageRP === current.combo.averageRP &&
+        combo.totalGames === current.combo.totalGames &&
+        combo.winRate > current.combo.winRate)
+    ) {
+      bestByTeammatePick.set(teammateKey, { combo, members });
+    }
+  }
+
+  const byMyPick = new Map<string, OrderedComboRecommendation>();
+
+  for (const entry of bestByTeammatePick.values()) {
+    const myMember = entry.members[0];
+    const key = `${myMember.character}:${myMember.weapon}`;
+    const current: OrderedComboRecommendation = byMyPick.get(key) ?? {
+      key,
+      myMember,
+      combos: [],
+    };
+    current.combos.push(entry);
+    byMyPick.set(key, current);
+  }
+
+  return Array.from(byMyPick.values())
+    .map((recommendation) => ({
+      ...recommendation,
+      combos: recommendation.combos.sort(
+        (a, b) =>
+          b.combo.averageRP - a.combo.averageRP ||
+          b.combo.totalGames - a.combo.totalGames ||
+          b.combo.winRate - a.combo.winRate
+      ),
+    }))
+    .sort((a, b) => {
+      const aBest = a.combos[0]?.combo;
+      const bBest = b.combos[0]?.combo;
+      if (!aBest && !bBest) return 0;
+      if (!aBest) return 1;
+      if (!bBest) return -1;
+      return (
+        bBest.averageRP - aBest.averageRP ||
+        bBest.totalGames - aBest.totalGames ||
+        bBest.winRate - aBest.winRate
+      );
+    });
+}
+
+function orderComboMembersByPlayerPools(
+  combo: TrioWeaponCombo,
+  pools: number[][]
+): OrderedComboMembers | null {
+  const selected: Array<TrioWeaponCombo["members"][number] | null> = Array(pools.length).fill(null);
+  const usedIndexes = new Set<number>();
+
+  function visit(playerIndex: number): boolean {
+    if (playerIndex >= pools.length) return true;
+
+    for (let memberIndex = 0; memberIndex < combo.members.length; memberIndex += 1) {
+      if (usedIndexes.has(memberIndex)) continue;
+      const member = combo.members[memberIndex];
+      if (!pools[playerIndex].includes(member.character)) continue;
+
+      selected[playerIndex] = member;
+      usedIndexes.add(memberIndex);
+      if (visit(playerIndex + 1)) return true;
+      usedIndexes.delete(memberIndex);
+      selected[playerIndex] = null;
+    }
+
+    return false;
+  }
+
+  if (!visit(0)) return null;
+  return selected as OrderedComboMembers;
+}
+
+function MyPickComboCard({
+  recommendation,
+  rank,
+}: {
+  recommendation: OrderedComboRecommendation;
+  rank: number;
+}) {
+  const { myMember, combos } = recommendation;
+  const bestCombo = combos[0]?.combo;
+  const tier = bestCombo
+    ? comboTier(bestCombo.winRate, bestCombo.averageRP, bestCombo.averageRank, bestCombo.totalGames)
+    : "D";
+
+  return (
+    <div className="flex min-h-[176px] flex-col gap-3 rounded-xl border border-[rgba(96,165,250,0.24)] bg-[rgba(96,165,250,0.055)] p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-xl border border-[rgba(255,255,255,0.1)] bg-[var(--color-surface-2)]">
+            <Image
+              src={getCharacterMiniWebpUrl(myMember.character)}
+              alt={characterDisplayName(myMember.character)}
+              fill
+              sizes="48px"
+              className="object-cover"
+              unoptimized
+            />
+          </div>
+          <div className="min-w-0">
+            <div className="flex items-center gap-1.5">
+              <span className="inline-flex h-6 min-w-7 items-center justify-center rounded-md bg-[var(--color-surface-3)] px-1.5 font-mono text-[10px] font-bold text-[var(--color-muted-foreground)]">
+                #{rank}
+              </span>
+              <span className="inline-flex h-6 min-w-7 items-center justify-center rounded-md border border-[rgba(251,191,36,0.24)] bg-[rgba(251,191,36,0.10)] px-1.5 font-mono text-xs font-black text-[var(--color-accent-gold)]">
+                {tier}
+              </span>
+            </div>
+            <p className="mt-1 truncate text-sm font-black text-[var(--color-foreground)]">
+              {memberDisplayName(myMember)}
+            </p>
+            <p className="truncate text-xs font-semibold text-[var(--color-muted-foreground)]">
+              내 픽 기준 RP 상위 팀원 조합
+            </p>
+          </div>
+        </div>
+        {bestCombo && (
+          <span
+            className={cn(
+              "rounded-lg px-2 py-1 font-mono text-sm font-black",
+              bestCombo.averageRP >= 0
+                ? "bg-[rgba(74,222,128,0.10)] text-[var(--color-stat-up)]"
+                : "bg-[rgba(248,113,113,0.10)] text-[var(--color-stat-down)]"
+            )}
+          >
+            {bestCombo.averageRP >= 0 ? "+" : ""}
+            {bestCombo.averageRP.toFixed(1)}
+          </span>
+        )}
+      </div>
+
+      {bestCombo && (
+        <div className="grid grid-cols-3 gap-1.5">
+          <CompactMetric label="승률" value={`${bestCombo.winRate.toFixed(1)}%`} />
+          <CompactMetric label="순위" value={`#${bestCombo.averageRank.toFixed(1)}`} />
+          <CompactMetric label="표본" value={bestCombo.totalGames.toLocaleString("ko-KR")} />
+        </div>
+      )}
+
+      <div className="mt-auto flex flex-col gap-1.5 border-t border-[var(--color-border)] pt-2">
+        <p className="text-[10px] font-bold uppercase tracking-wider text-[var(--color-muted-foreground)]">
+          팀원 픽 순서
+        </p>
+        {combos.map(({ combo, members }) => (
+          <Link
+            key={combo.id}
+            href={comboDetailHref(combo)}
+            scroll={false}
+            className="flex items-center justify-between gap-2 rounded-lg bg-[rgba(255,255,255,0.035)] px-2 py-1.5 text-[11px] transition hover:bg-[rgba(96,165,250,0.10)]"
+          >
+            <span className="min-w-0 truncate font-bold text-[var(--color-foreground)]">
+              {members
+                .slice(1)
+                .map((member) => memberDisplayName(member))
+                .join(" + ")}
+            </span>
+            <span className="shrink-0 font-mono font-bold text-[var(--color-stat-up)]">
+              {combo.averageRP >= 0 ? "+" : ""}
+              {combo.averageRP.toFixed(1)} RP
+            </span>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function CompactMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0 rounded-md bg-[rgba(255,255,255,0.035)] px-1 py-1">
+      <p className="text-[9px] font-semibold text-[var(--color-muted-foreground)]">{label}</p>
+      <p className="truncate font-mono text-[11px] font-bold text-[var(--color-foreground)]">
+        {value}
+      </p>
+    </div>
+  );
 }

--- a/frontend/src/components/features/multi-search/MultiSearchClient.tsx
+++ b/frontend/src/components/features/multi-search/MultiSearchClient.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { AlertTriangle, Loader2, Search, Trophy, Users } from "lucide-react";
+import { FormEvent, useMemo, useState } from "react";
+import { getFallbackMap } from "@/components/features/synergy/constants";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+interface MultiSearchResponse {
+  seasonId: number;
+  matchingMode: number;
+  results: PlayerResult[];
+}
+
+interface PlayerResult {
+  input: string;
+  status: "ok" | "not_found" | "no_stats" | "error";
+  nickname?: string;
+  seasonId?: number;
+  matchingMode?: number;
+  matchingTeamMode?: number;
+  mmr?: number;
+  rank?: number;
+  rankSize?: number;
+  totalGames?: number;
+  totalWins?: number;
+  winRate?: number;
+  top3Rate?: number;
+  averageRank?: number;
+  averageKills?: number;
+  averageAssistants?: number;
+  topCharacters?: Array<{
+    characterCode: number;
+    totalGames: number;
+    wins: number;
+    winRate: number;
+    top3: number;
+    top3Rate: number;
+    averageRank: number;
+    maxKillings: number;
+  }>;
+  reason?: string;
+}
+
+const EMPTY_INPUTS = ["", "", ""];
+
+export function MultiSearchClient() {
+  const [inputs, setInputs] = useState<string[]>(EMPTY_INPUTS);
+  const [data, setData] = useState<MultiSearchResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const characterNames = useMemo(() => getFallbackMap(), []);
+
+  const normalizedNicknames = useMemo(
+    () => inputs.map((value) => value.trim()).filter(Boolean),
+    [inputs]
+  );
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (normalizedNicknames.length === 0) {
+      setError("검색할 팀원 닉네임을 입력해주세요.");
+      setData(null);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/multi-search/players", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ nicknames: normalizedNicknames }),
+      });
+
+      const payload = await response.json();
+      if (!response.ok) {
+        const message = Array.isArray(payload?.message)
+          ? payload.message.join(" ")
+          : payload?.message || "멀티서치 요청에 실패했습니다.";
+        throw new Error(message);
+      }
+
+      setData(payload as MultiSearchResponse);
+    } catch (err) {
+      setData(null);
+      setError(err instanceof Error ? err.message : "멀티서치 요청에 실패했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  function updateInput(index: number, value: string) {
+    setInputs((current) => current.map((item, itemIndex) => (itemIndex === index ? value : item)));
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      <form
+        onSubmit={handleSubmit}
+        className="rounded-[22px] border border-[var(--color-border)] bg-[rgba(15,23,42,0.72)] p-4 shadow-[0_20px_48px_-36px_rgba(0,0,0,0.68)] sm:p-5"
+      >
+        <div className="grid gap-3 md:grid-cols-[1fr_1fr_1fr_auto]">
+          {inputs.map((value, index) => (
+            <label key={index} className="flex min-w-0 flex-col gap-2">
+              <span className="text-xs font-semibold text-[var(--color-muted-foreground)]">
+                팀원 {index + 1}
+              </span>
+              <input
+                value={value}
+                onChange={(event) => updateInput(index, event.target.value)}
+                maxLength={16}
+                autoComplete="off"
+                placeholder="닉네임"
+                className="h-11 rounded-xl border border-[var(--color-border)] bg-[rgba(8,13,25,0.86)] px-3 text-sm font-semibold text-[var(--color-foreground)] outline-none transition focus:border-[rgba(96,165,250,0.52)] focus:ring-2 focus:ring-[rgba(96,165,250,0.16)]"
+              />
+            </label>
+          ))}
+          <Button type="submit" size="lg" disabled={isLoading} className="mt-auto h-11 md:min-w-28">
+            {isLoading ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Search className="h-4 w-4" />
+            )}
+            검색
+          </Button>
+        </div>
+        {error && (
+          <div className="mt-4 flex items-start gap-2 rounded-xl border border-[rgba(248,113,113,0.28)] bg-[rgba(127,29,29,0.18)] px-3 py-2 text-sm text-[var(--color-danger)]">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+      </form>
+
+      {data && (
+        <section className="grid gap-4 lg:grid-cols-3">
+          {data.results.map((result) => (
+            <PlayerCard
+              key={result.input}
+              result={result}
+              getCharacterName={(code) => characterNames.get(code) ?? `#${code}`}
+            />
+          ))}
+        </section>
+      )}
+    </div>
+  );
+}
+
+function PlayerCard({
+  result,
+  getCharacterName,
+}: {
+  result: PlayerResult;
+  getCharacterName: (code: number) => string;
+}) {
+  if (result.status !== "ok") {
+    return (
+      <Card className="min-h-56">
+        <CardContent className="flex h-full flex-col justify-between gap-5 p-5">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl border border-[rgba(248,113,113,0.24)] bg-[rgba(127,29,29,0.18)] text-[var(--color-danger)]">
+              <AlertTriangle className="h-5 w-5" />
+            </div>
+            <div className="min-w-0">
+              <p className="truncate text-base font-bold text-[var(--color-foreground)]">
+                {result.input}
+              </p>
+              <p className="text-xs font-semibold text-[var(--color-muted-foreground)]">
+                {statusText(result.status)}
+              </p>
+            </div>
+          </div>
+          <p className="text-sm leading-6 text-[var(--color-muted-foreground)]">
+            닉네임을 다시 확인하거나 시즌 39 랭크 기록이 있는 팀원을 검색해주세요.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="overflow-hidden">
+      <CardContent className="flex flex-col gap-5 p-5">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="truncate text-lg font-black text-[var(--color-foreground)]">
+              {result.nickname}
+            </p>
+            <p className="mt-1 text-xs font-semibold text-[var(--color-muted-foreground)]">
+              시즌 {result.seasonId} · 스쿼드 랭크
+            </p>
+          </div>
+          <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-[rgba(96,165,250,0.26)] bg-[rgba(96,165,250,0.12)] text-[var(--color-primary)]">
+            <Trophy className="h-5 w-5" />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <Metric label="랭크" value={formatRank(result.rank, result.rankSize)} strong />
+          <Metric label="MMR" value={formatNumber(result.mmr)} strong />
+          <Metric label="승률" value={`${formatNumber(result.winRate)}%`} />
+          <Metric label="Top 3" value={`${formatNumber(result.top3Rate)}%`} />
+          <Metric label="평균 순위" value={formatNumber(result.averageRank)} />
+          <Metric label="평균 킬" value={formatNumber(result.averageKills)} />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-[var(--color-muted-foreground)]">
+            <Users className="h-3.5 w-3.5" />
+            주력 캐릭터
+          </div>
+          <div className="flex flex-col gap-2">
+            {(result.topCharacters ?? []).map((character) => (
+              <div
+                key={character.characterCode}
+                className="grid grid-cols-[1fr_auto] gap-3 rounded-xl border border-[var(--color-border)] bg-[rgba(255,255,255,0.03)] px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-bold text-[var(--color-foreground)]">
+                    {getCharacterName(character.characterCode)}
+                  </p>
+                  <p className="text-xs text-[var(--color-muted-foreground)]">
+                    {character.totalGames}게임 · 승률 {formatNumber(character.winRate)}%
+                  </p>
+                </div>
+                <div
+                  className={cn(
+                    "text-right text-xs font-semibold",
+                    character.top3Rate >= 50
+                      ? "text-[var(--color-stat-up)]"
+                      : "text-[var(--color-muted-foreground)]"
+                  )}
+                >
+                  Top 3
+                  <br />
+                  {formatNumber(character.top3Rate)}%
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  strong = false,
+}: {
+  label: string;
+  value: string;
+  strong?: boolean;
+}) {
+  return (
+    <div className="rounded-xl border border-[var(--color-border)] bg-[rgba(255,255,255,0.03)] px-3 py-2">
+      <p className="text-[11px] font-semibold text-[var(--color-muted-foreground)]">{label}</p>
+      <p
+        className={cn(
+          "mt-1 truncate font-black text-[var(--color-foreground)]",
+          strong ? "text-lg" : "text-base"
+        )}
+      >
+        {value}
+      </p>
+    </div>
+  );
+}
+
+function statusText(status: PlayerResult["status"]) {
+  if (status === "not_found") return "닉네임을 찾을 수 없습니다.";
+  if (status === "no_stats") return "시즌 통계가 없습니다.";
+  return "검색 중 오류가 발생했습니다.";
+}
+
+function formatNumber(value: number | undefined) {
+  if (value == null || Number.isNaN(value)) return "-";
+  return new Intl.NumberFormat("ko-KR", { maximumFractionDigits: 2 }).format(value);
+}
+
+function formatRank(rank: number | undefined, rankSize: number | undefined) {
+  if (!rank) return "-";
+  if (!rankSize) return `#${formatNumber(rank)}`;
+  return `#${formatNumber(rank)} / ${formatNumber(rankSize)}`;
+}

--- a/frontend/src/components/features/multi-search/MultiSearchClient.tsx
+++ b/frontend/src/components/features/multi-search/MultiSearchClient.tsx
@@ -64,18 +64,7 @@ interface PlayerResult {
     | "unknown_error";
 }
 
-interface PickRanking {
-  character: number;
-  weapon: number;
-  totalGames: number;
-  winRate: number;
-  averageRP: number;
-  averageRank: number;
-  bestComboIds: string[];
-}
-
 interface TeamCombosResponse {
-  pickRankings: PickRanking[];
   results: TrioWeaponCombo[];
 }
 
@@ -773,7 +762,6 @@ async function fetchTeamCombos(pools: number[][]): Promise<TeamCombosResponse> {
 
   const payload = (await response.json()) as Partial<TeamCombosResponse>;
   return {
-    pickRankings: payload.pickRankings ?? [],
     results: payload.results ?? [],
   };
 }

--- a/frontend/src/components/features/multi-search/MultiSearchClient.tsx
+++ b/frontend/src/components/features/multi-search/MultiSearchClient.tsx
@@ -22,6 +22,11 @@ interface MultiSearchResponse {
   seasonId: number;
   matchingMode: number;
   results: PlayerResult[];
+  summary?: {
+    requested: number;
+    ok: number;
+    failed: number;
+  };
 }
 
 interface PlayerResult {
@@ -51,7 +56,12 @@ interface PlayerResult {
     averageRank: number;
     maxKillings: number;
   }>;
-  reason?: string;
+  reason?:
+    | "nickname_not_found"
+    | "season_stats_not_found"
+    | "bser_api_key_missing"
+    | "bser_api_unavailable"
+    | "unknown_error";
 }
 
 interface PickRanking {
@@ -74,12 +84,11 @@ const MY_NICKNAME_STORAGE_KEY = "ermeta:multi-search:my-nickname";
 
 export function MultiSearchClient() {
   const [myNickname, setMyNickname] = useState("");
-  const [teammateInput, setTeammateInput] = useState("");
+  const [teammateInputs, setTeammateInputs] = useState<[string, string]>(["", ""]);
   const [myProfile, setMyProfile] = useState<PlayerResult | null>(null);
   const [myWeaponFilters, setMyWeaponFilters] = useState<Record<number, number>>({});
   const [data, setData] = useState<MultiSearchResponse | null>(null);
   const [teamCombos, setTeamCombos] = useState<TrioWeaponCombo[]>([]);
-  const [pickRankings, setPickRankings] = useState<PickRanking[]>([]);
   const [teammateCharacterFilters, setTeammateCharacterFilters] = useState<Array<number | null>>([
     null,
     null,
@@ -92,12 +101,9 @@ export function MultiSearchClient() {
   const characterNames = useMemo(() => getFallbackMap(), []);
 
   const teammateNicknames = useMemo(() => {
-    return teammateInput
-      .split(",")
-      .map((value) => value.trim())
-      .filter(Boolean)
-      .slice(0, 2);
-  }, [teammateInput]);
+    return buildTeammateNicknames(teammateInputs);
+  }, [teammateInputs]);
+  const searchSummary = useMemo(() => buildSearchSummary(data?.results ?? []), [data]);
 
   useEffect(() => {
     try {
@@ -127,7 +133,6 @@ export function MultiSearchClient() {
       const players = data?.results.filter((result) => result.status === "ok") ?? [];
       if (players.length !== 3) {
         setTeamCombos([]);
-        setPickRankings([]);
         setComboError(null);
         setIsComboLoading(false);
         return;
@@ -136,7 +141,6 @@ export function MultiSearchClient() {
       const pools = players.map((player) => getTopCharacterCodes(player));
       if (pools.some((pool) => pool.length === 0)) {
         setTeamCombos([]);
-        setPickRankings([]);
         setComboError("팀원별 주력 캐릭터 표본이 부족해 조합을 추천할 수 없습니다.");
         setIsComboLoading(false);
         return;
@@ -150,14 +154,12 @@ export function MultiSearchClient() {
         if (cancelled) return;
 
         setTeamCombos(recommendations.results);
-        setPickRankings(recommendations.pickRankings);
         setComboError(
           recommendations.results.length === 0 ? "조건에 맞는 조합 실험실 표본이 없습니다." : null
         );
       } catch {
         if (!cancelled) {
           setTeamCombos([]);
-          setPickRankings([]);
           setComboError("팀 조합 추천 데이터를 불러오지 못했습니다.");
         }
       } finally {
@@ -179,7 +181,6 @@ export function MultiSearchClient() {
       setMyProfile(null);
       setData(null);
       setTeamCombos([]);
-      setPickRankings([]);
       return;
     }
 
@@ -197,14 +198,12 @@ export function MultiSearchClient() {
       setMyProfile(profile);
       setData(null);
       setTeamCombos([]);
-      setPickRankings([]);
       setTeammateCharacterFilters([null, null]);
       setMyWeaponFilters(buildDefaultWeaponFilters(profile));
     } catch (err) {
       setMyProfile(null);
       setData(null);
       setTeamCombos([]);
-      setPickRankings([]);
       setTeammateCharacterFilters([null, null]);
       setMyWeaponFilters({});
       setError(err instanceof Error ? err.message : "내 정보 검색에 실패했습니다.");
@@ -220,10 +219,16 @@ export function MultiSearchClient() {
       return;
     }
     if (teammateNicknames.length < 2) {
-      setError("팀원 닉네임 2명을 쉼표로 구분해 입력해주세요.");
+      setError("팀원 닉네임 2명을 모두 입력해주세요.");
       setData(null);
       setTeamCombos([]);
-      setPickRankings([]);
+      setTeammateCharacterFilters([null, null]);
+      return;
+    }
+    if (hasDuplicateNicknames([myProfile.nickname ?? myProfile.input, ...teammateNicknames])) {
+      setError("내 닉네임과 팀원 닉네임은 서로 달라야 합니다.");
+      setData(null);
+      setTeamCombos([]);
       setTeammateCharacterFilters([null, null]);
       return;
     }
@@ -240,7 +245,6 @@ export function MultiSearchClient() {
     } catch (err) {
       setData(null);
       setTeamCombos([]);
-      setPickRankings([]);
       setTeammateCharacterFilters([null, null]);
       setError(err instanceof Error ? err.message : "멀티서치 요청에 실패했습니다.");
     } finally {
@@ -263,6 +267,26 @@ export function MultiSearchClient() {
         index === teammateIndex ? (selected === characterCode ? null : characterCode) : selected
       )
     );
+  }
+
+  function updateTeammateInput(index: number, value: string) {
+    setTeammateInputs((current) => {
+      const split = splitNicknameInput(value);
+      if (split.length > 1) {
+        const next: [string, string] = [current[0], current[1]];
+        next[index] = split[0] ?? "";
+        if (index === 0) next[1] = split[1] ?? next[1];
+        return next;
+      }
+
+      const next: [string, string] = [current[0], current[1]];
+      next[index] = value;
+      return next;
+    });
+    setData(null);
+    setTeamCombos([]);
+    setComboError(null);
+    setTeammateCharacterFilters([null, null]);
   }
 
   return (
@@ -313,21 +337,23 @@ export function MultiSearchClient() {
         onSubmit={handleTeamSubmit}
         className="rounded-2xl border border-[var(--color-border)] bg-[rgba(15,23,42,0.58)] p-3 shadow-[0_20px_48px_-36px_rgba(0,0,0,0.58)] sm:p-4"
       >
-        <div className="grid gap-2 lg:grid-cols-[1fr_auto]">
-          <label className="min-w-0">
-            <span className="sr-only">팀원 닉네임</span>
-            <input
-              value={teammateInput}
-              onChange={(event) => setTeammateInput(event.target.value)}
-              autoComplete="off"
-              placeholder="팀원 2명 닉네임, 쉼표로 구분"
-              className="h-10 w-full min-w-0 rounded-xl border border-[var(--color-border)] bg-[rgba(8,13,25,0.86)] px-3 text-sm font-semibold text-[var(--color-foreground)] outline-none transition focus:border-[rgba(96,165,250,0.52)] focus:ring-2 focus:ring-[rgba(96,165,250,0.16)]"
-            />
-          </label>
+        <div className="grid gap-2 lg:grid-cols-[1fr_1fr_auto]">
+          {[0, 1].map((index) => (
+            <label key={index} className="min-w-0">
+              <span className="sr-only">팀원 {index + 1} 닉네임</span>
+              <input
+                value={teammateInputs[index]}
+                onChange={(event) => updateTeammateInput(index, event.target.value)}
+                autoComplete="off"
+                placeholder={`팀원 ${index + 1} 닉네임`}
+                className="h-10 w-full min-w-0 rounded-xl border border-[var(--color-border)] bg-[rgba(8,13,25,0.86)] px-3 text-sm font-semibold text-[var(--color-foreground)] outline-none transition focus:border-[rgba(96,165,250,0.52)] focus:ring-2 focus:ring-[rgba(96,165,250,0.16)]"
+              />
+            </label>
+          ))}
           <Button
             type="submit"
             size="lg"
-            disabled={isTeamLoading || !myProfile}
+            disabled={isTeamLoading || !myProfile || teammateNicknames.length < 2}
             className="h-10 md:min-w-24"
           >
             {isTeamLoading ? (
@@ -347,20 +373,23 @@ export function MultiSearchClient() {
       </form>
 
       {data && (
-        <section className="grid gap-3 lg:grid-cols-3">
-          {data.results.map((result, index) => (
-            <PlayerCard
-              key={result.input}
-              result={result}
-              selectedCharacter={index > 0 ? (teammateCharacterFilters[index - 1] ?? null) : null}
-              onToggleCharacter={
-                index > 0
-                  ? (characterCode) => toggleTeammateCharacterFilter(index - 1, characterCode)
-                  : undefined
-              }
-              getCharacterName={(code) => characterNames.get(code) ?? `#${code}`}
-            />
-          ))}
+        <section className="flex flex-col gap-3">
+          {searchSummary && <SearchSummary summary={searchSummary} />}
+          <div className="grid gap-3 lg:grid-cols-3">
+            {data.results.map((result, index) => (
+              <PlayerCard
+                key={`${index}-${result.input}`}
+                result={result}
+                selectedCharacter={index > 0 ? (teammateCharacterFilters[index - 1] ?? null) : null}
+                onToggleCharacter={
+                  index > 0
+                    ? (characterCode) => toggleTeammateCharacterFilter(index - 1, characterCode)
+                    : undefined
+                }
+                getCharacterName={(code) => characterNames.get(code) ?? `#${code}`}
+              />
+            ))}
+          </div>
         </section>
       )}
 
@@ -402,12 +431,12 @@ function PlayerCard({
                 {result.input}
               </p>
               <p className="text-xs font-semibold text-[var(--color-muted-foreground)]">
-                {statusText(result.status)}
+                {playerStatusText(result)}
               </p>
             </div>
           </div>
           <p className="text-xs leading-5 text-[var(--color-muted-foreground)]">
-            닉네임 또는 시즌 39 랭크 기록을 확인해주세요.
+            {playerStatusDescription(result)}
           </p>
         </CardContent>
       </Card>
@@ -490,6 +519,50 @@ function PlayerCard({
         </div>
       </CardContent>
     </Card>
+  );
+}
+
+interface SearchSummaryState {
+  okCount: number;
+  failed: PlayerResult[];
+}
+
+function buildSearchSummary(results: PlayerResult[]): SearchSummaryState | null {
+  if (results.length === 0) return null;
+  const failed = results.filter((result) => result.status !== "ok");
+  if (failed.length === 0) return null;
+
+  return {
+    okCount: results.length - failed.length,
+    failed,
+  };
+}
+
+function SearchSummary({ summary }: { summary: SearchSummaryState }) {
+  return (
+    <div className="flex flex-col gap-2 rounded-xl border border-[rgba(251,191,36,0.24)] bg-[rgba(251,191,36,0.08)] px-3 py-2 text-sm text-[var(--color-foreground)]">
+      <div className="flex items-start gap-2">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-[var(--color-accent-gold)]" />
+        <div className="min-w-0">
+          <p className="font-bold">일부 플레이어 정보를 불러오지 못했습니다.</p>
+          <p className="mt-0.5 text-xs leading-5 text-[var(--color-muted-foreground)]">
+            성공 {summary.okCount}명 · 실패 {summary.failed.length}명. 세 명 모두 시즌 기록이
+            확인되어야 조합 추천을 계산합니다.
+          </p>
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {summary.failed.map((result) => (
+          <span
+            key={result.input}
+            className="inline-flex items-center gap-1 rounded-lg border border-[rgba(251,191,36,0.18)] bg-[rgba(8,13,25,0.38)] px-2 py-1 text-xs font-semibold text-[var(--color-muted-foreground)]"
+          >
+            <span className="max-w-32 truncate text-[var(--color-foreground)]">{result.input}</span>
+            <span>{playerStatusText(result)}</span>
+          </span>
+        ))}
+      </div>
+    </div>
   );
 }
 
@@ -601,15 +674,50 @@ function Metric({
   );
 }
 
-function statusText(status: PlayerResult["status"]) {
-  if (status === "not_found") return "닉네임을 찾을 수 없습니다.";
-  if (status === "no_stats") return "시즌 통계가 없습니다.";
+function playerStatusText(result: PlayerResult) {
+  if (result.status === "not_found") return "닉네임을 찾을 수 없습니다.";
+  if (result.status === "no_stats") return "시즌 통계가 없습니다.";
+  if (result.reason === "bser_api_key_missing") return "API 설정이 필요합니다.";
+  if (result.reason === "bser_api_unavailable") return "전적 API가 응답하지 않습니다.";
   return "검색 중 오류가 발생했습니다.";
+}
+
+function playerStatusDescription(result: PlayerResult) {
+  if (result.reason === "bser_api_key_missing") {
+    return "서버의 BSER API 키 설정을 확인해야 합니다.";
+  }
+  if (result.reason === "bser_api_unavailable") {
+    return "외부 전적 API 지연 또는 장애로 조회하지 못했습니다. 잠시 뒤 다시 시도해주세요.";
+  }
+  return "닉네임 또는 시즌 39 랭크 기록을 확인해주세요.";
 }
 
 function formatNumber(value: number | undefined) {
   if (value == null || Number.isNaN(value)) return "-";
   return new Intl.NumberFormat("ko-KR", { maximumFractionDigits: 2 }).format(value);
+}
+
+function splitNicknameInput(value: string): string[] {
+  return value
+    .split(/[,\n]/)
+    .map((nickname) => nickname.trim())
+    .filter(Boolean)
+    .slice(0, 2);
+}
+
+function buildTeammateNicknames(inputs: [string, string]): string[] {
+  return inputs.map((nickname) => nickname.trim()).filter(Boolean);
+}
+
+function hasDuplicateNicknames(nicknames: string[]): boolean {
+  const seen = new Set<string>();
+  for (const nickname of nicknames) {
+    const key = nickname.trim().toLocaleLowerCase("ko-KR");
+    if (!key) continue;
+    if (seen.has(key)) return true;
+    seen.add(key);
+  }
+  return false;
 }
 
 function getTopCharacterCodes(player: PlayerResult): number[] {
@@ -703,7 +811,9 @@ function TeamComboRecommendations({
   loading: boolean;
   error: string | null;
 }) {
-  const isReady = players.filter((player) => player.status === "ok").length === 3;
+  const okPlayers = players.filter((player) => player.status === "ok");
+  const failedPlayers = players.filter((player) => player.status !== "ok");
+  const isReady = okPlayers.length === 3;
   const activeWeaponFilterCount = Object.keys(myWeaponFilters).length;
   const recommendedCombos = useMemo(
     () =>
@@ -714,10 +824,6 @@ function TeamComboRecommendations({
     activeWeaponFilterCount > 0
       ? "팀원 후보 조합별 최적 내 픽"
       : "팀원 후보군에 맞는 내 캐릭터/무기";
-
-  if (!isReady) {
-    return null;
-  }
 
   return (
     <section className="flex flex-col gap-3 rounded-2xl border border-[var(--color-border)] bg-[rgba(15,23,42,0.58)] p-3 sm:p-4">
@@ -742,20 +848,32 @@ function TeamComboRecommendations({
         )}
       </div>
 
-      {error && !loading && (
+      {!isReady && (
+        <div className="flex items-start gap-2 rounded-xl border border-[rgba(251,191,36,0.24)] bg-[rgba(251,191,36,0.08)] px-3 py-2 text-sm text-[var(--color-muted-foreground)]">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-[var(--color-accent-gold)]" />
+          <span>
+            현재 검색 성공 {okPlayers.length}명입니다.{" "}
+            {failedPlayers.length > 0
+              ? `${failedPlayers.map((player) => player.input).join(", ")} 정보를 확인한 뒤 다시 검색해주세요.`
+              : "세 명의 시즌 기록이 모두 필요합니다."}
+          </span>
+        </div>
+      )}
+
+      {isReady && error && !loading && (
         <div className="flex items-start gap-2 rounded-xl border border-[rgba(248,113,113,0.24)] bg-[rgba(127,29,29,0.16)] px-3 py-2 text-sm text-[var(--color-danger)]">
           <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
           <span>{error}</span>
         </div>
       )}
 
-      {!loading && !error && recommendedCombos.length === 0 && combos.length > 0 && (
+      {isReady && !loading && !error && recommendedCombos.length === 0 && combos.length > 0 && (
         <div className="rounded-xl border border-[var(--color-border)] bg-[rgba(255,255,255,0.035)] px-3 py-2 text-sm text-[var(--color-muted-foreground)]">
           설정한 캐릭터별 무기군과 맞는 표본이 없습니다.
         </div>
       )}
 
-      {!loading && !error && recommendedCombos.length > 0 && (
+      {isReady && !loading && !error && recommendedCombos.length > 0 && (
         <div className="grid gap-2 lg:grid-cols-3">
           {recommendedCombos.map((recommendation, index) => (
             <MyPickComboCard

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -10,6 +10,7 @@ import {
   NotebookText,
   Search,
   Trophy,
+  Users,
   type LucideIcon,
 } from "lucide-react";
 import Link from "next/link";
@@ -77,6 +78,13 @@ export function Navigation({ currentPatch, patchAnalysisPatch, onNavigate }: Nav
       label: "조합 실험실",
       icon: FlaskConical,
       isActive: normalizedPathname.startsWith("/trio-lab"),
+    },
+    {
+      href: withCurrentRouteLocale(pathname, "/multi-search"),
+      label: "팀원 멀티서치",
+      icon: Users,
+      isActive: normalizedPathname.startsWith("/multi-search"),
+      badge: "new",
     },
     {
       href: withCurrentRouteLocale(pathname, "/character-lab"),

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -10,7 +10,6 @@ import {
   NotebookText,
   Search,
   Trophy,
-  Users,
   type LucideIcon,
 } from "lucide-react";
 import Link from "next/link";
@@ -78,13 +77,6 @@ export function Navigation({ currentPatch, patchAnalysisPatch, onNavigate }: Nav
       label: "조합 실험실",
       icon: FlaskConical,
       isActive: normalizedPathname.startsWith("/trio-lab"),
-    },
-    {
-      href: withCurrentRouteLocale(pathname, "/multi-search"),
-      label: "팀원 멀티서치",
-      icon: Users,
-      isActive: normalizedPathname.startsWith("/multi-search"),
-      badge: "new",
     },
     {
       href: withCurrentRouteLocale(pathname, "/character-lab"),

--- a/frontend/src/lib/featureFlags.ts
+++ b/frontend/src/lib/featureFlags.ts
@@ -1,0 +1,6 @@
+export function isMultiSearchEnabled(): boolean {
+  return (
+    process.env.ENABLE_MULTI_SEARCH === "true" ||
+    process.env.NEXT_PUBLIC_ENABLE_MULTI_SEARCH === "true"
+  );
+}


### PR DESCRIPTION
## 변경 사항

  - 팀원 닉네임 3개를 한 번에 입력해 시즌 랭크 정보를 조회하는 멀티서치 화면을 추가했습니다.
  - 내 닉네임 저장, 최근 입력 유지, 입력 검증, 요청 제한 등 기본 사용 흐름을 정리했습니다.
  - `/api/multi-search/players` 프록시 API를 추가해 백엔드 멀티서치 조회와 연결했습니다.
  - `/api/multi-search/team-combos` API를 추가해 팀원 캐릭터 풀 기반 조합 추천 데이터를 계산하도록 했습니다.
  - 멀티서치 결과에서 랭크, MMR, 승률, Top 캐릭터, 팀 조합 추천을 확인할 수 있도록 UI를 구성했습니다.
  - MVP는 아직 사용자에게 공개하지 않기 위해 네비게이션 노출을 제거하고, feature flag가 꺼져 있으면 페이지/API가 404를 반환하도록 처리했습니다.
    - `ENABLE_MULTI_SEARCH=true` 또는 `NEXT_PUBLIC_ENABLE_MULTI_SEARCH=true`일 때만 접근 가능합니다.


## 테스트 결과 (테스트를 했으면)
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.