### PR TITLE
[feat] 광고 적용

### DIFF
--- a/.github/workflows/perf-ci.yml
+++ b/.github/workflows/perf-ci.yml
@@ -45,12 +45,14 @@ jobs:
           NEXT_PUBLIC_BASE_URL: http://localhost:3000
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          NEXT_PUBLIC_ADSENSE_DISABLED: "true"
         run: npm run build
 
       - name: Start server
         run: npm run start &
         env:
           PORT: 3000
+          NEXT_PUBLIC_ADSENSE_DISABLED: "true"
 
       - name: Wait for server
         run: npx --yes wait-on http://localhost:3000 -t 60000

--- a/frontend/src/__tests__/analytics.test.ts
+++ b/frontend/src/__tests__/analytics.test.ts
@@ -225,6 +225,41 @@ describe("analytics — P0 helpers", () => {
     });
   });
 
+  describe("ad slot events", () => {
+    it("ad_slot_rendered 에 슬롯명과 광고 슬롯 ID 를 전달한다", async () => {
+      analytics.adSlotRendered({
+        slotName: "synergy_detail_top",
+        adSlotId: "8139813658",
+        pagePath: "/ko/synergy-detail",
+      });
+      await flushAsync();
+      expect(trackMock).toHaveBeenCalledWith("ad_slot_rendered", {
+        slot_name: "synergy_detail_top",
+        ad_slot_id: "8139813658",
+        page_path: "/ko/synergy-detail",
+      });
+    });
+
+    it("ad_slot_viewed 에 슬롯명과 viewport 정보를 전달한다", async () => {
+      Object.defineProperty(window, "innerWidth", { configurable: true, value: 390 });
+      Object.defineProperty(window, "innerHeight", { configurable: true, value: 844 });
+
+      analytics.adSlotViewed({
+        slotName: "home_ranking",
+        adSlotId: "8139813658",
+        pagePath: "/ko",
+      });
+      await flushAsync();
+      expect(trackMock).toHaveBeenCalledWith("ad_slot_viewed", {
+        slot_name: "home_ranking",
+        ad_slot_id: "8139813658",
+        page_path: "/ko",
+        viewport_width: 390,
+        viewport_height: 844,
+      });
+    });
+  });
+
   describe("setSessionProperties (Identify API)", () => {
     it("Identify 인스턴스로 amplitude.identify 를 호출한다", async () => {
       analytics.setSessionProperties({

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -355,6 +355,36 @@
   color: var(--color-foreground);
 }
 
+.ad-placement {
+  position: relative;
+  display: block;
+  width: 100%;
+}
+
+.ad-placement-label {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--color-muted-foreground);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.ad-placement-preview-box {
+  display: grid;
+  min-height: 96px;
+  place-items: center;
+  border: 1px dashed rgba(148, 163, 184, 0.36);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.025);
+  color: var(--color-muted-foreground);
+  font-size: 12px;
+  font-weight: 700;
+}
+
 .role-pill {
   position: relative;
   padding: 9px 14px;

--- a/frontend/src/components/ads/AdSenseScript.tsx
+++ b/frontend/src/components/ads/AdSenseScript.tsx
@@ -2,8 +2,8 @@
 
 import { usePathname } from "next/navigation";
 import Script from "next/script";
+import { ADSENSE_CLIENT } from "@/components/ads/adsenseConfig";
 
-const ADSENSE_CLIENT = process.env.NEXT_PUBLIC_ADSENSE_CLIENT;
 const CONTENT_PATH_PREFIXES = [
   "/",
   "/about",
@@ -12,6 +12,7 @@ const CONTENT_PATH_PREFIXES = [
   "/patches",
   "/patch-analysis",
   "/season10-recap",
+  "/synergy-detail",
 ];
 
 function stripLocale(pathname: string) {

--- a/frontend/src/components/ads/AdSlot.tsx
+++ b/frontend/src/components/ads/AdSlot.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { ADSENSE_CLIENT, ADSENSE_PREVIEW } from "@/components/ads/adsenseConfig";
+import { analytics, type AdSlotName } from "@/lib/analytics";
 
 declare global {
   interface Window {
@@ -11,6 +12,7 @@ declare global {
 
 interface AdSlotProps {
   slot: string;
+  slotName: AdSlotName;
   format?: "auto" | "fluid" | "rectangle" | "horizontal" | "vertical";
   layout?: string;
   layoutKey?: string;
@@ -21,6 +23,7 @@ interface AdSlotProps {
 
 export function AdSlot({
   slot,
+  slotName,
   format = "auto",
   layout,
   layoutKey,
@@ -29,6 +32,9 @@ export function AdSlot({
   minHeight = 100,
 }: AdSlotProps) {
   const pushed = useRef(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const renderedTracked = useRef(false);
+  const viewedTracked = useRef(false);
 
   useEffect(() => {
     if (ADSENSE_PREVIEW || !ADSENSE_CLIENT || !slot || pushed.current) return;
@@ -40,9 +46,57 @@ export function AdSlot({
     }
   }, [slot]);
 
+  useEffect(() => {
+    if (!slot || renderedTracked.current) return;
+    renderedTracked.current = true;
+    analytics.adSlotRendered({ slotName, adSlotId: slot });
+  }, [slot, slotName]);
+
+  useEffect(() => {
+    if (!slot || viewedTracked.current) return;
+    const element = rootRef.current;
+    if (!element || typeof IntersectionObserver === "undefined") return;
+
+    let viewTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const clearViewTimer = () => {
+      if (!viewTimer) return;
+      clearTimeout(viewTimer);
+      viewTimer = null;
+    };
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry || viewedTracked.current) return;
+        if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
+          if (viewTimer) return;
+          viewTimer = setTimeout(() => {
+            viewedTracked.current = true;
+            analytics.adSlotViewed({ slotName, adSlotId: slot });
+            observer.disconnect();
+          }, 1000);
+        } else {
+          clearViewTimer();
+        }
+      },
+      { threshold: [0, 0.5, 1] }
+    );
+
+    observer.observe(element);
+
+    return () => {
+      clearViewTimer();
+      observer.disconnect();
+    };
+  }, [slot, slotName]);
+
   if (ADSENSE_PREVIEW) {
     return (
-      <div className={`ad-placement ad-placement-preview ${className ?? ""}`} style={{ minHeight }}>
+      <div
+        ref={rootRef}
+        className={`ad-placement ad-placement-preview ${className ?? ""}`}
+        style={{ minHeight }}
+      >
         <span className="ad-placement-label">Advertisement</span>
         <div className="ad-placement-preview-box">AdSense preview</div>
       </div>
@@ -52,7 +106,7 @@ export function AdSlot({
   if (!ADSENSE_CLIENT || !slot) return null;
 
   return (
-    <div className={`ad-placement ${className ?? ""}`} style={{ minHeight }}>
+    <div ref={rootRef} className={`ad-placement ${className ?? ""}`} style={{ minHeight }}>
       <span className="ad-placement-label">Advertisement</span>
       <ins
         className="adsbygoogle block"

--- a/frontend/src/components/ads/AdSlot.tsx
+++ b/frontend/src/components/ads/AdSlot.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-
-const ADSENSE_CLIENT = process.env.NEXT_PUBLIC_ADSENSE_CLIENT;
+import { ADSENSE_CLIENT, ADSENSE_PREVIEW } from "@/components/ads/adsenseConfig";
 
 declare global {
   interface Window {
@@ -32,27 +31,39 @@ export function AdSlot({
   const pushed = useRef(false);
 
   useEffect(() => {
-    if (!ADSENSE_CLIENT || pushed.current) return;
+    if (ADSENSE_PREVIEW || !ADSENSE_CLIENT || !slot || pushed.current) return;
     try {
       (window.adsbygoogle = window.adsbygoogle || []).push({});
       pushed.current = true;
     } catch {
       // adsbygoogle may not be loaded yet; loader script will retry on script load
     }
-  }, []);
+  }, [slot]);
 
-  if (!ADSENSE_CLIENT) return null;
+  if (ADSENSE_PREVIEW) {
+    return (
+      <div className={`ad-placement ad-placement-preview ${className ?? ""}`} style={{ minHeight }}>
+        <span className="ad-placement-label">Advertisement</span>
+        <div className="ad-placement-preview-box">AdSense preview</div>
+      </div>
+    );
+  }
+
+  if (!ADSENSE_CLIENT || !slot) return null;
 
   return (
-    <ins
-      className={`adsbygoogle block ${className ?? ""}`}
-      style={{ display: "block", minHeight, width: "100%" }}
-      data-ad-client={ADSENSE_CLIENT}
-      data-ad-slot={slot}
-      data-ad-format={format}
-      data-ad-layout={layout}
-      data-ad-layout-key={layoutKey}
-      data-full-width-responsive={responsive ? "true" : "false"}
-    />
+    <div className={`ad-placement ${className ?? ""}`} style={{ minHeight }}>
+      <span className="ad-placement-label">Advertisement</span>
+      <ins
+        className="adsbygoogle block"
+        style={{ display: "block", minHeight, width: "100%" }}
+        data-ad-client={ADSENSE_CLIENT}
+        data-ad-slot={slot}
+        data-ad-format={format}
+        data-ad-layout={layout}
+        data-ad-layout-key={layoutKey}
+        data-full-width-responsive={responsive ? "true" : "false"}
+      />
+    </div>
   );
 }

--- a/frontend/src/components/ads/AdSlot.tsx
+++ b/frontend/src/components/ads/AdSlot.tsx
@@ -31,16 +31,19 @@ export function AdSlot({
   className,
   minHeight = 100,
 }: AdSlotProps) {
-  const pushed = useRef(false);
   const rootRef = useRef<HTMLDivElement | null>(null);
+  const insRef = useRef<HTMLModElement | null>(null);
+  const pushedElement = useRef<HTMLModElement | null>(null);
   const renderedTracked = useRef(false);
   const viewedTracked = useRef(false);
 
   useEffect(() => {
-    if (ADSENSE_PREVIEW || !ADSENSE_CLIENT || !slot || pushed.current) return;
+    const element = insRef.current;
+    if (ADSENSE_PREVIEW || !ADSENSE_CLIENT || !slot || !element) return;
+    if (pushedElement.current === element) return;
     try {
       (window.adsbygoogle = window.adsbygoogle || []).push({});
-      pushed.current = true;
+      pushedElement.current = element;
     } catch {
       // adsbygoogle may not be loaded yet; loader script will retry on script load
     }
@@ -109,6 +112,8 @@ export function AdSlot({
     <div ref={rootRef} className={`ad-placement ${className ?? ""}`} style={{ minHeight }}>
       <span className="ad-placement-label">Advertisement</span>
       <ins
+        key={`${slotName}:${slot}`}
+        ref={insRef}
         className="adsbygoogle block"
         style={{ display: "block", minHeight, width: "100%" }}
         data-ad-client={ADSENSE_CLIENT}

--- a/frontend/src/components/ads/adsenseConfig.ts
+++ b/frontend/src/components/ads/adsenseConfig.ts
@@ -1,11 +1,12 @@
 const DEFAULT_ADSENSE_CLIENT = "ca-pub-4008956736614349";
 const DEFAULT_DISPLAY_SLOT = "8139813658";
 const ADSENSE_DISABLED = process.env.NEXT_PUBLIC_ADSENSE_DISABLED === "true";
+const productionDefault = process.env.NODE_ENV === "production" ? DEFAULT_DISPLAY_SLOT : "";
 
 export const ADSENSE_CLIENT = ADSENSE_DISABLED
   ? ""
-  : process.env.NEXT_PUBLIC_ADSENSE_CLIENT ||
-    (process.env.NODE_ENV === "production" ? DEFAULT_ADSENSE_CLIENT : "");
+  : (process.env.NEXT_PUBLIC_ADSENSE_CLIENT ??
+    (process.env.NODE_ENV === "production" ? DEFAULT_ADSENSE_CLIENT : ""));
 
 export const ADSENSE_PREVIEW =
   !ADSENSE_DISABLED && process.env.NEXT_PUBLIC_ADSENSE_PREVIEW === "true";
@@ -13,12 +14,10 @@ export const ADSENSE_PREVIEW =
 export const ADSENSE_SLOTS = {
   homeRanking: ADSENSE_DISABLED
     ? ""
-    : process.env.NEXT_PUBLIC_ADSENSE_HOME_RANKING_SLOT ||
-      (process.env.NODE_ENV === "production" ? DEFAULT_DISPLAY_SLOT : ""),
+    : (process.env.NEXT_PUBLIC_ADSENSE_HOME_RANKING_SLOT ?? productionDefault),
   synergyDetail: ADSENSE_DISABLED
     ? ""
-    : process.env.NEXT_PUBLIC_ADSENSE_SYNERGY_DETAIL_SLOT ||
-      (process.env.NODE_ENV === "production" ? DEFAULT_DISPLAY_SLOT : ""),
+    : (process.env.NEXT_PUBLIC_ADSENSE_SYNERGY_DETAIL_SLOT ?? productionDefault),
 } as const;
 
 export function canRenderAdSlot(slot: string) {

--- a/frontend/src/components/ads/adsenseConfig.ts
+++ b/frontend/src/components/ads/adsenseConfig.ts
@@ -1,0 +1,17 @@
+const DEFAULT_ADSENSE_CLIENT = "ca-pub-4008956736614349";
+const DEFAULT_DISPLAY_SLOT = "8139813658";
+
+export const ADSENSE_CLIENT =
+  process.env.NEXT_PUBLIC_ADSENSE_CLIENT ||
+  (process.env.NODE_ENV === "production" ? DEFAULT_ADSENSE_CLIENT : "");
+
+export const ADSENSE_PREVIEW = process.env.NEXT_PUBLIC_ADSENSE_PREVIEW === "true";
+
+export const ADSENSE_SLOTS = {
+  homeRanking:
+    process.env.NEXT_PUBLIC_ADSENSE_HOME_RANKING_SLOT ||
+    (process.env.NODE_ENV === "production" ? DEFAULT_DISPLAY_SLOT : ""),
+  synergyDetail:
+    process.env.NEXT_PUBLIC_ADSENSE_SYNERGY_DETAIL_SLOT ||
+    (process.env.NODE_ENV === "production" ? DEFAULT_DISPLAY_SLOT : ""),
+} as const;

--- a/frontend/src/components/ads/adsenseConfig.ts
+++ b/frontend/src/components/ads/adsenseConfig.ts
@@ -1,17 +1,26 @@
 const DEFAULT_ADSENSE_CLIENT = "ca-pub-4008956736614349";
 const DEFAULT_DISPLAY_SLOT = "8139813658";
+const ADSENSE_DISABLED = process.env.NEXT_PUBLIC_ADSENSE_DISABLED === "true";
 
-export const ADSENSE_CLIENT =
-  process.env.NEXT_PUBLIC_ADSENSE_CLIENT ||
-  (process.env.NODE_ENV === "production" ? DEFAULT_ADSENSE_CLIENT : "");
+export const ADSENSE_CLIENT = ADSENSE_DISABLED
+  ? ""
+  : process.env.NEXT_PUBLIC_ADSENSE_CLIENT ||
+    (process.env.NODE_ENV === "production" ? DEFAULT_ADSENSE_CLIENT : "");
 
-export const ADSENSE_PREVIEW = process.env.NEXT_PUBLIC_ADSENSE_PREVIEW === "true";
+export const ADSENSE_PREVIEW =
+  !ADSENSE_DISABLED && process.env.NEXT_PUBLIC_ADSENSE_PREVIEW === "true";
 
 export const ADSENSE_SLOTS = {
-  homeRanking:
-    process.env.NEXT_PUBLIC_ADSENSE_HOME_RANKING_SLOT ||
-    (process.env.NODE_ENV === "production" ? DEFAULT_DISPLAY_SLOT : ""),
-  synergyDetail:
-    process.env.NEXT_PUBLIC_ADSENSE_SYNERGY_DETAIL_SLOT ||
-    (process.env.NODE_ENV === "production" ? DEFAULT_DISPLAY_SLOT : ""),
+  homeRanking: ADSENSE_DISABLED
+    ? ""
+    : process.env.NEXT_PUBLIC_ADSENSE_HOME_RANKING_SLOT ||
+      (process.env.NODE_ENV === "production" ? DEFAULT_DISPLAY_SLOT : ""),
+  synergyDetail: ADSENSE_DISABLED
+    ? ""
+    : process.env.NEXT_PUBLIC_ADSENSE_SYNERGY_DETAIL_SLOT ||
+      (process.env.NODE_ENV === "production" ? DEFAULT_DISPLAY_SLOT : ""),
 } as const;
+
+export function canRenderAdSlot(slot: string) {
+  return ADSENSE_PREVIEW || (Boolean(ADSENSE_CLIENT) && Boolean(slot));
+}

--- a/frontend/src/components/features/home/HomeDashboardSections.tsx
+++ b/frontend/src/components/features/home/HomeDashboardSections.tsx
@@ -2,6 +2,8 @@
 
 import { useTranslations } from "next-intl";
 import * as React from "react";
+import { ADSENSE_SLOTS } from "@/components/ads/adsenseConfig";
+import { AdSlot } from "@/components/ads/AdSlot";
 import { FilterProvider, useFilter } from "@/components/features/FilterContext";
 import { GlobalFilter } from "@/components/features/GlobalFilter";
 import { HomeFilterAside } from "@/components/features/HomeFilterAside";
@@ -109,6 +111,12 @@ function HomeDashboardSectionsBody({
       </section>
 
       <HomeFilterAside anchorId="home-top-filter" />
+
+      <AdSlot
+        slot={ADSENSE_SLOTS.homeRanking}
+        className="dashboard-panel px-3 py-2.5 sm:px-4"
+        minHeight={120}
+      />
 
       <section className="dashboard-panel p-4 lg:p-5">
         <div className="mb-4 flex flex-wrap items-end gap-x-4 gap-y-2">

--- a/frontend/src/components/features/home/HomeDashboardSections.tsx
+++ b/frontend/src/components/features/home/HomeDashboardSections.tsx
@@ -2,7 +2,7 @@
 
 import { useTranslations } from "next-intl";
 import * as React from "react";
-import { ADSENSE_SLOTS } from "@/components/ads/adsenseConfig";
+import { ADSENSE_SLOTS, canRenderAdSlot } from "@/components/ads/adsenseConfig";
 import { AdSlot } from "@/components/ads/AdSlot";
 import { FilterProvider, useFilter } from "@/components/features/FilterContext";
 import { GlobalFilter } from "@/components/features/GlobalFilter";
@@ -112,12 +112,14 @@ function HomeDashboardSectionsBody({
 
       <HomeFilterAside anchorId="home-top-filter" />
 
-      <AdSlot
-        slot={ADSENSE_SLOTS.homeRanking}
-        slotName="home_ranking"
-        className="dashboard-panel px-3 py-2.5 sm:px-4"
-        minHeight={120}
-      />
+      {canRenderAdSlot(ADSENSE_SLOTS.homeRanking) ? (
+        <AdSlot
+          slot={ADSENSE_SLOTS.homeRanking}
+          slotName="home_ranking"
+          className="dashboard-panel px-3 py-2.5 sm:px-4"
+          minHeight={120}
+        />
+      ) : null}
 
       <section className="dashboard-panel p-4 lg:p-5">
         <div className="mb-4 flex flex-wrap items-end gap-x-4 gap-y-2">

--- a/frontend/src/components/features/home/HomeDashboardSections.tsx
+++ b/frontend/src/components/features/home/HomeDashboardSections.tsx
@@ -114,6 +114,7 @@ function HomeDashboardSectionsBody({
 
       <AdSlot
         slot={ADSENSE_SLOTS.homeRanking}
+        slotName="home_ranking"
         className="dashboard-panel px-3 py-2.5 sm:px-4"
         minHeight={120}
       />

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -44,6 +44,8 @@ export type SynergySortBy = "averageRP" | "winRate" | "averageRank" | "totalGame
 
 export type SessionSource = "organic_search" | "community" | "direct" | "social" | "internal";
 
+export type AdSlotName = "home_ranking" | "synergy_detail_top";
+
 export interface SessionProperties {
   session_source?: SessionSource;
   is_patch_day?: boolean;
@@ -240,6 +242,36 @@ export const analytics = {
     method: "native" | "clipboard" | null;
   }) {
     track("synergy_link_landed", args);
+  },
+
+  /** 광고 슬롯 DOM 렌더링 — 실제 광고 fill 여부와 무관하게 슬롯 노출 후보를 측정한다. */
+  adSlotRendered(args: { slotName: AdSlotName; adSlotId: string; pagePath?: string }) {
+    track("ad_slot_rendered", {
+      slot_name: args.slotName,
+      ad_slot_id: args.adSlotId,
+      page_path:
+        args.pagePath ?? (typeof window !== "undefined" ? window.location.pathname : undefined),
+    });
+  },
+
+  /** 광고 슬롯이 viewport 에 50% 이상 1초 머문 경우. 클릭 추적은 AdSense 정책상 하지 않는다. */
+  adSlotViewed(args: { slotName: AdSlotName; adSlotId: string; pagePath?: string }) {
+    const viewport =
+      typeof window !== "undefined"
+        ? {
+            width: window.innerWidth,
+            height: window.innerHeight,
+          }
+        : undefined;
+
+    track("ad_slot_viewed", {
+      slot_name: args.slotName,
+      ad_slot_id: args.adSlotId,
+      page_path:
+        args.pagePath ?? (typeof window !== "undefined" ? window.location.pathname : undefined),
+      viewport_width: viewport?.width,
+      viewport_height: viewport?.height,
+    });
   },
 
   // ── Identify (User / Session Properties) ───────────────────────────────────

--- a/frontend/src/views/synergy-detail/SynergyDetailPage.tsx
+++ b/frontend/src/views/synergy-detail/SynergyDetailPage.tsx
@@ -200,6 +200,7 @@ export default function SynergyDetailPage() {
 
       <AdSlot
         slot={ADSENSE_SLOTS.synergyDetail}
+        slotName="synergy_detail_top"
         className="dashboard-panel px-3 py-2.5 sm:px-4"
         minHeight={120}
       />

--- a/frontend/src/views/synergy-detail/SynergyDetailPage.tsx
+++ b/frontend/src/views/synergy-detail/SynergyDetailPage.tsx
@@ -3,6 +3,8 @@ import type { Metadata } from "next";
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
 import type { ReactNode } from "react";
+import { ADSENSE_SLOTS } from "@/components/ads/adsenseConfig";
+import { AdSlot } from "@/components/ads/AdSlot";
 import { SynergyDetailClient } from "@/components/features/synergy-detail/SynergyDetailClient";
 import { getCharacterName } from "@/lib/characterMap";
 import { BASE_URL } from "@/lib/siteMetadata";
@@ -195,6 +197,12 @@ export default function SynergyDetailPage() {
           </div>
         </div>
       </section>
+
+      <AdSlot
+        slot={ADSENSE_SLOTS.synergyDetail}
+        className="dashboard-panel px-3 py-2.5 sm:px-4"
+        minHeight={120}
+      />
 
       <SynergyDetailClient />
     </div>

--- a/frontend/src/views/synergy-detail/SynergyDetailPage.tsx
+++ b/frontend/src/views/synergy-detail/SynergyDetailPage.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
 import type { ReactNode } from "react";
-import { ADSENSE_SLOTS } from "@/components/ads/adsenseConfig";
+import { ADSENSE_SLOTS, canRenderAdSlot } from "@/components/ads/adsenseConfig";
 import { AdSlot } from "@/components/ads/AdSlot";
 import { SynergyDetailClient } from "@/components/features/synergy-detail/SynergyDetailClient";
 import { getCharacterName } from "@/lib/characterMap";
@@ -198,12 +198,14 @@ export default function SynergyDetailPage() {
         </div>
       </section>
 
-      <AdSlot
-        slot={ADSENSE_SLOTS.synergyDetail}
-        slotName="synergy_detail_top"
-        className="dashboard-panel px-3 py-2.5 sm:px-4"
-        minHeight={120}
-      />
+      {canRenderAdSlot(ADSENSE_SLOTS.synergyDetail) ? (
+        <AdSlot
+          slot={ADSENSE_SLOTS.synergyDetail}
+          slotName="synergy_detail_top"
+          className="dashboard-panel px-3 py-2.5 sm:px-4"
+          minHeight={120}
+        />
+      ) : null}
 
       <SynergyDetailClient />
     </div>


### PR DESCRIPTION
• ## 변경 사항

  AdSense 광고 로더와 수동 광고 슬롯을 추가했습니다.

  - AdSense 공통 설정 추가
  - 공통 `AdSlot` 컴포넌트 개선
    - 광고 슬롯 ID가 없으면 렌더링하지 않도록 처리
    - 로컬 프리뷰용 placeholder 지원
  - 홈 랭킹 영역 위에 광고 슬롯 추가
  - 상세 조합 추천 상단 소개 블록 아래에 광고 슬롯 추가
  - `/synergy-detail` 경로에서도 AdSense 스크립트가 로드되도록 적용
## 테스트 결과 (테스트를 했으면)
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.


<img width="1296" height="643" alt="스크린샷 2026-06-16 오후 3 52 26" src="https://github.com/user-attachments/assets/279694f9-9735-4e56-8ebc-2ebe24b2c825" />
