### PR TITLE
[feat] 탐색 퍼널 고도화

### DIFF
--- a/frontend/src/__tests__/analytics.test.ts
+++ b/frontend/src/__tests__/analytics.test.ts
@@ -225,6 +225,67 @@ describe("analytics — P0 helpers", () => {
     });
   });
 
+  describe("synergy exploration funnel events", () => {
+    it("탐색 깊이 증가 이벤트를 전달한다", async () => {
+      analytics.synergyExplorationAdvanced({
+        ally1Code: 1,
+        ally2Code: 2,
+        resultCount: 20,
+        sortBy: "averageRP",
+        explorationDepth: 3,
+        isWeaponScope: false,
+        source: "filter_change",
+      });
+      await flushAsync();
+      expect(trackMock).toHaveBeenCalledWith("synergy_exploration_advanced", {
+        ally1Code: 1,
+        ally2Code: 2,
+        resultCount: 20,
+        sortBy: "averageRP",
+        explorationDepth: 3,
+        isWeaponScope: false,
+        source: "filter_change",
+      });
+    });
+
+    it("퍼널 종료 이벤트에 상세 조회 여부를 담는다", async () => {
+      analytics.synergyFunnelExited({
+        ally1Code: 1,
+        ally2Code: null,
+        resultCount: 12,
+        sortBy: "winRate",
+        explorationDepth: 2,
+        openedDetail: false,
+        isWeaponScope: false,
+      });
+      await flushAsync();
+      expect(trackMock).toHaveBeenCalledWith("synergy_funnel_exited", {
+        ally1Code: 1,
+        ally2Code: null,
+        resultCount: 12,
+        sortBy: "winRate",
+        explorationDepth: 2,
+        openedDetail: false,
+        isWeaponScope: false,
+      });
+    });
+
+    it("recommendation prefetch 이벤트는 trigger 와 source 를 전달한다", async () => {
+      analytics.synergyRecommendationPrefetched({
+        pickedCode: 3,
+        pickedRank: 1,
+        trigger: "viewport",
+      });
+      await flushAsync();
+      expect(trackMock).toHaveBeenCalledWith("synergy_recommendation_prefetched", {
+        pickedCode: 3,
+        pickedRank: 1,
+        trigger: "viewport",
+        source: "synergy",
+      });
+    });
+  });
+
   describe("ad slot events", () => {
     it("ad_slot_rendered 에 슬롯명과 광고 슬롯 ID 를 전달한다", async () => {
       analytics.adSlotRendered({

--- a/frontend/src/components/features/synergy-detail/SynergyDetailResults.tsx
+++ b/frontend/src/components/features/synergy-detail/SynergyDetailResults.tsx
@@ -15,7 +15,12 @@ import { isMobileDevice } from "@/lib/device";
 import { FetchHttpError, FetchRetriesExhaustedError, fetchWithRetry } from "@/lib/fetchWithRetry";
 import { cn } from "@/lib/utils";
 import { resolveWeaponName } from "@/lib/weaponMap";
-import { getAllCharacterCodes, getFallbackMap, SORT_OPTIONS } from "../synergy/constants";
+import {
+  getAllCharacterCodes,
+  getFallbackMap,
+  parseSortByParam,
+  SORT_OPTIONS,
+} from "../synergy/constants";
 import { ComboWeaponCard, type GroupedCombo } from "./ComboWeaponCard";
 import type { TrioWeaponResult, SortBy } from "./types";
 import {
@@ -104,6 +109,41 @@ function groupByCharWeapon(results: TrioWeaponResult[]): GroupedCombo[] {
 
 function sortAllyPair<T extends { charCode: number }>(allies: T[]): T[] {
   return [...allies].sort((a, b) => a.charCode - b.charCode);
+}
+
+function getAllyQueryKey(allies: AllySelection[]) {
+  return sortAllyPair(allies)
+    .map((ally) => `${ally.charCode}:${ally.weaponCode ?? 0}`)
+    .join("|");
+}
+
+function buildDetailSearchParams(allies: AllySelection[]) {
+  const params = new URLSearchParams({ sortBy: "totalGames", limit: "5000" });
+  const queryAllies = sortAllyPair(allies);
+  const a1 = queryAllies[0];
+  if (a1) {
+    params.set("character1", String(a1.charCode));
+    if (a1.weaponCode) params.set("weapon1", String(a1.weaponCode));
+  }
+  const a2 = queryAllies[1];
+  if (a2) {
+    params.set("character2", String(a2.charCode));
+    if (a2.weaponCode) params.set("weapon2", String(a2.weaponCode));
+  }
+  return params;
+}
+
+async function fetchDetailRows(allies: AllySelection[], signal?: AbortSignal) {
+  const params = buildDetailSearchParams(allies);
+  const data = await fetchWithRetry<{ results?: TrioWeaponResult[]; error?: string }>(
+    `/api/stats/trios-weapon?${params.toString()}`,
+    { signal }
+  );
+  return data.results ?? [];
+}
+
+function isAbortError(error: unknown) {
+  return error instanceof DOMException && error.name === "AbortError";
 }
 
 function prioritizeFocusGroups(
@@ -219,11 +259,23 @@ export function SynergyDetailResults() {
     [deferredAllies]
   );
 
-  const [sortBy, setSortBy] = React.useState<SortBy>("averageRP");
-  const [results, setResults] = React.useState<TrioWeaponResult[]>([]);
-  const [loading, setLoading] = React.useState(false);
-  const [error, setError] = React.useState<string | null>(null);
+  const urlSortBy = React.useMemo(() => parseSortByParam(searchParams.get("sort")), [searchParams]);
+  const [sortBy, setSortBy] = React.useState<SortBy>(urlSortBy);
+  const [queryAllies, setQueryAllies] = React.useState<AllySelection[]>(deferredAllies);
+  const [resultsState, setResultsState] = React.useState<{
+    data: TrioWeaponResult[];
+    error: unknown;
+    loading: boolean;
+  }>(() => ({
+    data: [],
+    error: null,
+    loading: deferredAllies.length > 0,
+  }));
   const [visibleCount, setVisibleCount] = React.useState(VISIBLE_RESULTS_STEP);
+
+  React.useEffect(() => {
+    setSortBy(urlSortBy);
+  }, [urlSortBy]);
 
   /**
    * 1번 탭 즉각 반응 핵심:
@@ -246,7 +298,65 @@ export function SynergyDetailResults() {
     }
     return false;
   }, [selectedAllies, deferredAllies]);
-  const showLoading = loading || isAllyChangeInFlight;
+  React.useEffect(() => {
+    if (deferredAllies.length === 0) {
+      setQueryAllies([]);
+      return;
+    }
+
+    const timerId = setTimeout(() => {
+      const nextKey = getAllyQueryKey(deferredAllies);
+      setQueryAllies((prev) => (getAllyQueryKey(prev) === nextKey ? prev : deferredAllies));
+    }, 180);
+
+    return () => clearTimeout(timerId);
+  }, [deferredAllies]);
+
+  React.useEffect(() => {
+    if (queryAllies.length === 0) {
+      setResultsState({ data: [], error: null, loading: false });
+      return;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+    setResultsState((prev) => ({ ...prev, error: null, loading: true }));
+
+    fetchDetailRows(queryAllies, controller.signal)
+      .then((data) => {
+        if (cancelled) return;
+        setResultsState({ data, error: null, loading: false });
+      })
+      .catch((err: unknown) => {
+        if (cancelled || isAbortError(err)) return;
+        setResultsState({ data: [], error: err, loading: false });
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [queryAllies]);
+
+  const deferredAlliesKey = React.useMemo(() => getAllyQueryKey(deferredAllies), [deferredAllies]);
+  const queryAlliesKey = React.useMemo(() => getAllyQueryKey(queryAllies), [queryAllies]);
+  const isQueryAlliesPending = deferredAllies.length > 0 && deferredAlliesKey !== queryAlliesKey;
+  const showLoading = isAllyChangeInFlight || isQueryAlliesPending || resultsState.loading;
+  const results = React.useMemo(
+    () => (isQueryAlliesPending ? [] : resultsState.data),
+    [isQueryAlliesPending, resultsState.data]
+  );
+  const error = React.useMemo(() => {
+    const err = resultsState.error;
+    if (!err || deferredAllies.length === 0 || isQueryAlliesPending) return null;
+    if (err instanceof DOMException && err.name === "TimeoutError") return t("timeout");
+    if (err instanceof FetchRetriesExhaustedError) return t("genericError");
+    if (err instanceof FetchHttpError) {
+      const body = err.body as { error?: string } | null;
+      return body?.error ?? t("genericError");
+    }
+    return err instanceof Error ? err.message : t("genericError");
+  }, [deferredAllies.length, isQueryAlliesPending, resultsState.error, t]);
   const [copied, setCopied] = React.useState(false);
   const virtualListRef = React.useRef<HTMLDivElement>(null);
   const [virtualScrollMargin, setVirtualScrollMargin] = React.useState(0);
@@ -291,72 +401,6 @@ export function SynergyDetailResults() {
     },
     [deferredCharCodes, focusCharWeapons]
   );
-
-  // API 호출 — deferredAllies 기반 (아군 선택 탭 즉시성 확보). 정렬은 클라이언트에서 처리해 CDN 키를 줄인다.
-  React.useEffect(() => {
-    if (deferredAllies.length === 0) {
-      setResults([]);
-      setLoading(false);
-      return;
-    }
-
-    const controller = new AbortController();
-    const timerId = setTimeout(() => {
-      const params = new URLSearchParams({ sortBy: "totalGames", limit: "5000" });
-      const queryAllies = sortAllyPair(deferredAllies);
-      const a1 = queryAllies[0];
-      if (a1) {
-        params.set("character1", String(a1.charCode));
-        if (a1.weaponCode) params.set("weapon1", String(a1.weaponCode));
-      }
-      const a2 = queryAllies[1];
-      if (a2) {
-        params.set("character2", String(a2.charCode));
-        if (a2.weaponCode) params.set("weapon2", String(a2.weaponCode));
-      }
-
-      setError(null);
-
-      fetchWithRetry<{ results?: TrioWeaponResult[]; error?: string }>(
-        `/api/stats/trios-weapon?${params.toString()}`,
-        { signal: controller.signal }
-      )
-        .then((data) => {
-          // setResults + setLoading(false)를 같은 startTransition 배치에 넣어
-          // "로딩 꺼짐 → 결과 렌더 전" 사이 '결과 없음' 빈 화면이 깜빡이는 것을 방지.
-          React.startTransition(() => {
-            setResults(data.results ?? []);
-            setLoading(false);
-          });
-        })
-        .catch((err) => {
-          if (err instanceof DOMException && err.name === "AbortError") return;
-          // 에러 경로는 urgent 유지 — 즉시 에러 메시지 표시
-          setLoading(false);
-          if (err instanceof DOMException && err.name === "TimeoutError") {
-            setError(t("timeout"));
-            return;
-          }
-          if (err instanceof FetchRetriesExhaustedError) {
-            setError(t("genericError"));
-            return;
-          }
-          if (err instanceof FetchHttpError) {
-            const body = err.body as { error?: string } | null;
-            setError(body?.error ?? t("genericError"));
-            return;
-          }
-          setError(err instanceof Error ? err.message : t("genericError"));
-        });
-    }, 300);
-
-    setLoading(true);
-    return () => {
-      clearTimeout(timerId);
-      controller.abort();
-      setLoading(false);
-    };
-  }, [deferredAllies, t]);
 
   // Two-level aggregation + focus-priority sorting — deferred 기반
   const recommendations = React.useMemo(() => {
@@ -413,15 +457,67 @@ export function SynergyDetailResults() {
     router.replace(pathname, { scroll: false });
   }, [router, pathname]);
 
+  const updateSortBy = React.useCallback(
+    (nextSortBy: SortBy) => {
+      if (nextSortBy === sortBy) return;
+      setSortBy(nextSortBy);
+      const params = new URLSearchParams(searchParams.toString());
+      if (nextSortBy === "averageRP") params.delete("sort");
+      else params.set("sort", nextSortBy);
+      const nextUrl = params.toString() ? `${pathname}?${params.toString()}` : pathname;
+      router.replace(nextUrl, { scroll: false });
+      analytics.synergySortChanged(nextSortBy);
+    },
+    [pathname, router, searchParams, sortBy]
+  );
+
   // synergy_result_viewed — 같은 (ally1,ally2,sortBy) 조합은 중복 fire 금지
   const lastViewedKeyRef = React.useRef<string | null>(null);
+  const explorationDepthRef = React.useRef(0);
+  const funnelStateRef = React.useRef<{
+    viewed: boolean;
+    openedDetail: boolean;
+    ally1Code: number | null;
+    ally2Code: number | null;
+    resultCount: number;
+    sortBy: SynergySortBy;
+    explorationDepth: number;
+  }>({
+    viewed: false,
+    openedDetail: false,
+    ally1Code: null,
+    ally2Code: null,
+    resultCount: 0,
+    sortBy: "averageRP",
+    explorationDepth: 0,
+  });
+
   React.useEffect(() => {
     if (showLoading || deferredAllies.length === 0 || recommendations.length === 0) return;
     const a1 = deferredCharCodes[0] ?? null;
     const a2 = deferredCharCodes[1] ?? null;
-    const key = `${a1 ?? "_"}|${a2 ?? "_"}|${sortBy}`;
+    const allyKey = getAllyQueryKey(deferredAllies);
+    const key = `${allyKey}|${sortBy}`;
     if (lastViewedKeyRef.current === key) return;
+    const previousKey = lastViewedKeyRef.current;
+    const previousAllyKey = previousKey ? previousKey.split("|").slice(0, -1).join("|") : null;
+    const source =
+      previousKey === null && typeof window !== "undefined" && window.location.search
+        ? "url_restore"
+        : previousAllyKey === allyKey
+          ? "sort_change"
+          : "filter_change";
     lastViewedKeyRef.current = key;
+    explorationDepthRef.current += 1;
+    funnelStateRef.current = {
+      viewed: true,
+      openedDetail: false,
+      ally1Code: a1,
+      ally2Code: a2,
+      resultCount: recommendations.length,
+      sortBy: sortBy as SynergySortBy,
+      explorationDepth: explorationDepthRef.current,
+    };
     analytics.synergyResultViewed({
       ally1Code: a1,
       ally2Code: a2,
@@ -431,7 +527,46 @@ export function SynergyDetailResults() {
       patch: "",
       isWeaponScope: true,
     });
+    analytics.synergyExplorationAdvanced({
+      ally1Code: a1,
+      ally2Code: a2,
+      resultCount: recommendations.length,
+      sortBy: sortBy as SynergySortBy,
+      explorationDepth: explorationDepthRef.current,
+      isWeaponScope: true,
+      source,
+    });
   }, [showLoading, recommendations, deferredAllies, deferredCharCodes, sortBy]);
+
+  const emitFunnelExit = React.useCallback(() => {
+    const state = funnelStateRef.current;
+    if (!state.viewed) return;
+    analytics.synergyFunnelExited({
+      ally1Code: state.ally1Code,
+      ally2Code: state.ally2Code,
+      resultCount: state.resultCount,
+      sortBy: state.sortBy,
+      explorationDepth: state.explorationDepth,
+      openedDetail: state.openedDetail,
+      isWeaponScope: true,
+    });
+    state.viewed = false;
+  }, []);
+
+  React.useEffect(() => {
+    const handlePageHide = () => emitFunnelExit();
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") emitFunnelExit();
+    };
+
+    window.addEventListener("pagehide", handlePageHide);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      emitFunnelExit();
+      window.removeEventListener("pagehide", handlePageHide);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [emitFunnelExit]);
 
   // synergy_recommendation_clicked — ref-stable 콜백 (ComboWeaponCard memo 보존)
   const recClickStateRef = React.useRef({ deferredCharCodes, sortBy });
@@ -440,6 +575,7 @@ export function SynergyDetailResults() {
   }, [deferredCharCodes, sortBy]);
   const onRecommendationClick = React.useCallback((pickedCode: number, pickedRank: number) => {
     const { deferredCharCodes: allies, sortBy: currentSortBy } = recClickStateRef.current;
+    funnelStateRef.current.openedDetail = true;
     analytics.synergyRecommendationClicked({
       ally1Code: allies[0] ?? null,
       ally2Code: allies[1] ?? null,
@@ -562,10 +698,7 @@ export function SynergyDetailResults() {
           {SORT_OPTIONS.map(({ value, labelKey }) => (
             <button
               key={value}
-              onClick={() => {
-                setSortBy(value);
-                analytics.synergySortChanged(value);
-              }}
+              onClick={() => updateSortBy(value)}
               className={cn(
                 "dashboard-tab flex min-h-[30px] shrink-0 items-center px-3 py-1 text-[12px] font-semibold",
                 sortBy === value

--- a/frontend/src/components/features/synergy-detail/SynergyDetailResults.tsx
+++ b/frontend/src/components/features/synergy-detail/SynergyDetailResults.tsx
@@ -259,8 +259,7 @@ export function SynergyDetailResults() {
     [deferredAllies]
   );
 
-  const urlSortBy = React.useMemo(() => parseSortByParam(searchParams.get("sort")), [searchParams]);
-  const [sortBy, setSortBy] = React.useState<SortBy>(urlSortBy);
+  const sortBy = React.useMemo(() => parseSortByParam(searchParams.get("sort")), [searchParams]);
   const [queryAllies, setQueryAllies] = React.useState<AllySelection[]>(deferredAllies);
   const [resultsState, setResultsState] = React.useState<{
     data: TrioWeaponResult[];
@@ -272,10 +271,6 @@ export function SynergyDetailResults() {
     loading: deferredAllies.length > 0,
   }));
   const [visibleCount, setVisibleCount] = React.useState(VISIBLE_RESULTS_STEP);
-
-  React.useEffect(() => {
-    setSortBy(urlSortBy);
-  }, [urlSortBy]);
 
   /**
    * 1번 탭 즉각 반응 핵심:
@@ -460,7 +455,6 @@ export function SynergyDetailResults() {
   const updateSortBy = React.useCallback(
     (nextSortBy: SortBy) => {
       if (nextSortBy === sortBy) return;
-      setSortBy(nextSortBy);
       const params = new URLSearchParams(searchParams.toString());
       if (nextSortBy === "averageRP") params.delete("sort");
       else params.set("sort", nextSortBy);

--- a/frontend/src/components/features/synergy/ComboCard.tsx
+++ b/frontend/src/components/features/synergy/ComboCard.tsx
@@ -17,6 +17,8 @@ export function ComboCard({
   isTopResult = false,
   compact = false,
   priorityImages = false,
+  prefetchOnViewport = false,
+  onPrefetchAnalysis,
   onNavigateAnalysis,
 }: {
   rec: TrioResult;
@@ -28,31 +30,64 @@ export function ComboCard({
   compact?: boolean;
   /** true면 이미지를 priority로 즉시 로드 (상위 카드용) */
   priorityImages?: boolean;
+  prefetchOnViewport?: boolean;
+  onPrefetchAnalysis?: (code: number, rank: number, trigger: "hover" | "viewport") => void;
   onNavigateAnalysis?: (code: number) => void;
 }) {
   // 선택한 아군을 앞에, 추천 캐릭터를 마지막에 표시
-  const allChars = [rec.character1, rec.character2, rec.character3];
-  const allies: number[] = [];
-  const rest: number[] = [];
-  for (const code of allChars) {
-    if (selectedAllies.includes(code) && allies.length < selectedAllies.length) {
-      allies.push(code);
-    } else {
-      rest.push(code);
+  const { chars, rest } = React.useMemo(() => {
+    const allChars = [rec.character1, rec.character2, rec.character3];
+    const nextAllies: number[] = [];
+    const nextRest: number[] = [];
+    for (const code of allChars) {
+      if (selectedAllies.includes(code) && nextAllies.length < selectedAllies.length) {
+        nextAllies.push(code);
+      } else {
+        nextRest.push(code);
+      }
     }
-  }
-  // 선택 순서 유지
-  allies.sort((a, b) => selectedAllies.indexOf(a) - selectedAllies.indexOf(b));
-  const chars = [...allies, ...rest];
+    // 선택 순서 유지
+    nextAllies.sort((a, b) => selectedAllies.indexOf(a) - selectedAllies.indexOf(b));
+    return { chars: [...nextAllies, ...nextRest], rest: nextRest };
+  }, [rec.character1, rec.character2, rec.character3, selectedAllies]);
   const isSmallSample = rec.totalGames < SMALL_SAMPLE_THRESHOLD;
+  const cardRef = React.useRef<HTMLDivElement>(null);
+
+  const prefetchRecommended = React.useCallback(
+    (trigger: "hover" | "viewport") => {
+      if (!onPrefetchAnalysis) return;
+      for (const code of rest) onPrefetchAnalysis(code, rank, trigger);
+    },
+    [onPrefetchAnalysis, rank, rest]
+  );
+
+  React.useEffect(() => {
+    if (!prefetchOnViewport || !onPrefetchAnalysis) return;
+    const element = cardRef.current;
+    if (!element || typeof IntersectionObserver === "undefined") return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((entry) => entry.isIntersecting)) return;
+        prefetchRecommended("viewport");
+        observer.disconnect();
+      },
+      { rootMargin: "240px 0px", threshold: 0.1 }
+    );
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [onPrefetchAnalysis, prefetchOnViewport, prefetchRecommended]);
 
   return (
     <div
+      ref={cardRef}
       className={cn(
         "combo-card",
         "group flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2.5 transition-colors hover:border-[var(--color-border-light)] hover:bg-[var(--color-surface-2)]"
       )}
       data-accent={isFocusPoolCombo || isTopResult ? "true" : undefined}
+      onPointerEnter={() => prefetchRecommended("hover")}
     >
       {/* 순위 */}
       <span
@@ -110,6 +145,7 @@ export function ComboCard({
               {isRecommended && onNavigateAnalysis ? (
                 <button
                   type="button"
+                  onFocus={() => onPrefetchAnalysis?.(code, rank, "hover")}
                   onClick={() => onNavigateAnalysis(code)}
                   className="group/char relative z-10 cursor-pointer flex items-center gap-1"
                   title={`${getCharName(code)} 분석 보기`}

--- a/frontend/src/components/features/synergy/SynergyResults.tsx
+++ b/frontend/src/components/features/synergy/SynergyResults.tsx
@@ -161,8 +161,7 @@ export function SynergyResults({ compact = false }: { compact?: boolean }) {
     return allies;
   }, [searchParams]);
 
-  const urlSortBy = React.useMemo(() => parseSortByParam(searchParams.get("sort")), [searchParams]);
-  const [sortBy, setSortBy] = React.useState<SortBy>(urlSortBy);
+  const sortBy = React.useMemo(() => parseSortByParam(searchParams.get("sort")), [searchParams]);
   const [queryAllies, setQueryAllies] = React.useState<number[]>(selectedAllies);
   const [resultsState, setResultsState] = React.useState<{
     data: TrioResult[];
@@ -174,10 +173,6 @@ export function SynergyResults({ compact = false }: { compact?: boolean }) {
     loading: selectedAllies.length > 0,
   }));
   const [copied, setCopied] = React.useState(false);
-
-  React.useEffect(() => {
-    setSortBy(urlSortBy);
-  }, [urlSortBy]);
 
   const getCharName = React.useCallback(
     (code: number) => resolveCharacterName(code, l10n, getFallbackMap()),
@@ -276,7 +271,6 @@ export function SynergyResults({ compact = false }: { compact?: boolean }) {
   const updateSortBy = React.useCallback(
     (nextSortBy: SortBy) => {
       if (nextSortBy === sortBy) return;
-      setSortBy(nextSortBy);
       const params = new URLSearchParams(searchParams.toString());
       if (nextSortBy === "averageRP") params.delete("sort");
       else params.set("sort", nextSortBy);

--- a/frontend/src/components/features/synergy/SynergyResults.tsx
+++ b/frontend/src/components/features/synergy/SynergyResults.tsx
@@ -7,12 +7,12 @@ import * as React from "react";
 import { SectionErrorBoundary } from "@/components/features/SectionErrorBoundary";
 import { useL10n } from "@/components/L10nProvider";
 import { useFocusCharacters } from "@/hooks/useFocusCharacters";
-import { analytics, type SynergySortBy } from "@/lib/analytics";
+import { analytics, type SynergyPrefetchTrigger, type SynergySortBy } from "@/lib/analytics";
 import { resolveCharacterName } from "@/lib/characterMap";
 import { isMobileDevice } from "@/lib/device";
 import { FetchHttpError, FetchRetriesExhaustedError, fetchWithRetry } from "@/lib/fetchWithRetry";
 import { withCurrentRouteLocale } from "@/lib/localizedPath";
-import { getAllCharacterCodes, getFallbackMap, SORT_OPTIONS } from "./constants";
+import { getAllCharacterCodes, getFallbackMap, parseSortByParam, SORT_OPTIONS } from "./constants";
 import type { TrioResult, SortBy } from "./types";
 import { getThirdCharacter, deduplicateResults } from "./utils";
 const ComboCard = React.lazy(() => import("./ComboCard").then((m) => ({ default: m.ComboCard })));
@@ -73,6 +73,31 @@ function mergeTrioWeaponRowsByCharacters(rows: TrioWeaponApiRow[]): TrioResult[]
 
 function sortCharacterPair(characters: number[]): number[] {
   return [...characters].sort((a, b) => a - b);
+}
+
+function getCharacterPairKey(characters: number[]) {
+  return sortCharacterPair(characters).join(":");
+}
+
+function buildTrioWeaponSearchParams(selectedAllies: number[]) {
+  const params = new URLSearchParams({ sortBy: "totalGames", limit: "5000" });
+  const queryAllies = sortCharacterPair(selectedAllies);
+  if (queryAllies[0] !== undefined) params.set("character1", String(queryAllies[0]));
+  if (queryAllies[1] !== undefined) params.set("character2", String(queryAllies[1]));
+  return params;
+}
+
+async function fetchTrioWeaponRows(selectedAllies: number[], signal?: AbortSignal) {
+  const params = buildTrioWeaponSearchParams(selectedAllies);
+  const data = await fetchWithRetry<{ results?: TrioWeaponApiRow[]; error?: string }>(
+    `/api/stats/trios-weapon?${params.toString()}`,
+    { signal }
+  );
+  return mergeTrioWeaponRowsByCharacters(data.results ?? []);
+}
+
+function isAbortError(error: unknown) {
+  return error instanceof DOMException && error.name === "AbortError";
 }
 
 function isFocusResult(rec: TrioResult, selectedAllies: number[], focusCharacters: number[]) {
@@ -136,68 +161,95 @@ export function SynergyResults({ compact = false }: { compact?: boolean }) {
     return allies;
   }, [searchParams]);
 
-  const [sortBy, setSortBy] = React.useState<SortBy>("averageRP");
-  const [trioResults, setTrioResults] = React.useState<TrioResult[]>([]);
-  const [loading, setLoading] = React.useState(false);
-  const [error, setError] = React.useState<string | null>(null);
+  const urlSortBy = React.useMemo(() => parseSortByParam(searchParams.get("sort")), [searchParams]);
+  const [sortBy, setSortBy] = React.useState<SortBy>(urlSortBy);
+  const [queryAllies, setQueryAllies] = React.useState<number[]>(selectedAllies);
+  const [resultsState, setResultsState] = React.useState<{
+    data: TrioResult[];
+    error: unknown;
+    loading: boolean;
+  }>(() => ({
+    data: [],
+    error: null,
+    loading: selectedAllies.length > 0,
+  }));
   const [copied, setCopied] = React.useState(false);
+
+  React.useEffect(() => {
+    setSortBy(urlSortBy);
+  }, [urlSortBy]);
 
   const getCharName = React.useCallback(
     (code: number) => resolveCharacterName(code, l10n, getFallbackMap()),
     [l10n]
   );
 
-  // API 호출: 아군 선택 시 (300ms 디바운스 + AbortController). 정렬은 클라이언트에서 처리해 CDN 키를 줄인다.
+  // 조건 변경 중에는 잠깐 기다렸다가 최종 조합만 요청한다.
+  // 요청 파라미터는 정렬된 캐릭터 pair라서 A+B와 B+A가 같은 HTTP 캐시 키를 공유한다.
   React.useEffect(() => {
     if (selectedAllies.length === 0) {
-      setTrioResults([]);
-      setLoading(false);
+      setQueryAllies([]);
       return;
     }
 
-    const controller = new AbortController();
     const timerId = setTimeout(() => {
-      const params = new URLSearchParams({ sortBy: "totalGames", limit: "5000" });
-      const queryAllies = sortCharacterPair(selectedAllies);
-      if (queryAllies[0] !== undefined) params.set("character1", String(queryAllies[0]));
-      if (queryAllies[1] !== undefined) params.set("character2", String(queryAllies[1]));
+      const nextKey = getCharacterPairKey(selectedAllies);
+      setQueryAllies((prev) => (getCharacterPairKey(prev) === nextKey ? prev : selectedAllies));
+    }, 180);
 
-      setError(null);
-
-      fetchWithRetry<{ results?: TrioWeaponApiRow[]; error?: string }>(
-        `/api/stats/trios-weapon?${params.toString()}`,
-        { signal: controller.signal }
-      )
-        .then((data) => {
-          setTrioResults(mergeTrioWeaponRowsByCharacters(data.results ?? []));
-        })
-        .catch((err) => {
-          if (err instanceof DOMException && err.name === "AbortError") return;
-          if (err instanceof DOMException && err.name === "TimeoutError") {
-            setError(t("timeout"));
-            return;
-          }
-          if (err instanceof FetchRetriesExhaustedError) {
-            setError(t("genericError"));
-            return;
-          }
-          if (err instanceof FetchHttpError) {
-            const body = err.body as { error?: string } | null;
-            setError(body?.error ?? t("genericError"));
-            return;
-          }
-          setError(err instanceof Error ? err.message : t("genericError"));
-        })
-        .finally(() => setLoading(false));
-    }, 300);
-
-    setLoading(true);
     return () => {
       clearTimeout(timerId);
-      controller.abort();
-      setLoading(false);
     };
-  }, [selectedAllies, t]);
+  }, [selectedAllies]);
+
+  React.useEffect(() => {
+    if (queryAllies.length === 0) {
+      setResultsState({ data: [], error: null, loading: false });
+      return;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+    setResultsState((prev) => ({ ...prev, error: null, loading: true }));
+
+    fetchTrioWeaponRows(queryAllies, controller.signal)
+      .then((data) => {
+        if (cancelled) return;
+        setResultsState({ data, error: null, loading: false });
+      })
+      .catch((err: unknown) => {
+        if (cancelled || isAbortError(err)) return;
+        setResultsState({ data: [], error: err, loading: false });
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [queryAllies]);
+
+  const selectedAlliesKey = React.useMemo(
+    () => getCharacterPairKey(selectedAllies),
+    [selectedAllies]
+  );
+  const queryAlliesKey = React.useMemo(() => getCharacterPairKey(queryAllies), [queryAllies]);
+  const isSelectionPending = selectedAllies.length > 0 && selectedAlliesKey !== queryAlliesKey;
+  const trioResults = React.useMemo(
+    () => (isSelectionPending ? [] : resultsState.data),
+    [isSelectionPending, resultsState.data]
+  );
+  const loading = selectedAllies.length > 0 && (isSelectionPending || resultsState.loading);
+  const error = React.useMemo(() => {
+    const err = resultsState.error;
+    if (!err || selectedAllies.length === 0 || isSelectionPending) return null;
+    if (err instanceof DOMException && err.name === "TimeoutError") return t("timeout");
+    if (err instanceof FetchRetriesExhaustedError) return t("genericError");
+    if (err instanceof FetchHttpError) {
+      const body = err.body as { error?: string } | null;
+      return body?.error ?? t("genericError");
+    }
+    return err instanceof Error ? err.message : t("genericError");
+  }, [isSelectionPending, resultsState.error, selectedAllies.length, t]);
 
   const recommendations = React.useMemo(() => {
     if (selectedAllies.length === 0) return [];
@@ -218,16 +270,83 @@ export function SynergyResults({ compact = false }: { compact?: boolean }) {
   }, [trioResults, selectedAllies, focusCharacters, sortBy]);
 
   const clearAllies = React.useCallback(() => {
-    router.replace(withCurrentRouteLocale(pathname, "/synergy-detail"), { scroll: false });
+    router.replace(pathname, { scroll: false });
   }, [pathname, router]);
+
+  const updateSortBy = React.useCallback(
+    (nextSortBy: SortBy) => {
+      if (nextSortBy === sortBy) return;
+      setSortBy(nextSortBy);
+      const params = new URLSearchParams(searchParams.toString());
+      if (nextSortBy === "averageRP") params.delete("sort");
+      else params.set("sort", nextSortBy);
+      const nextUrl = params.toString() ? `${pathname}?${params.toString()}` : pathname;
+      router.replace(nextUrl, { scroll: false });
+      analytics.synergySortChanged(nextSortBy);
+    },
+    [pathname, router, searchParams, sortBy]
+  );
+
+  const prefetchedAnalysisRef = React.useRef(new Set<number>());
+  const prefetchAnalysis = React.useCallback(
+    (code: number, rank: number, trigger: SynergyPrefetchTrigger) => {
+      if (prefetchedAnalysisRef.current.has(code)) return;
+      prefetchedAnalysisRef.current.add(code);
+      router.prefetch(withCurrentRouteLocale(pathname, `/character/${code}`));
+      analytics.synergyRecommendationPrefetched({
+        pickedCode: code,
+        pickedRank: rank,
+        trigger,
+      });
+    },
+    [pathname, router]
+  );
 
   // synergy_result_viewed — 같은 (ally1,ally2,sortBy) 조합은 중복 fire 금지
   const lastViewedKeyRef = React.useRef<string | null>(null);
+  const explorationDepthRef = React.useRef(0);
+  const funnelStateRef = React.useRef<{
+    viewed: boolean;
+    openedDetail: boolean;
+    ally1Code: number | null;
+    ally2Code: number | null;
+    resultCount: number;
+    sortBy: SynergySortBy;
+    explorationDepth: number;
+  }>({
+    viewed: false,
+    openedDetail: false,
+    ally1Code: null,
+    ally2Code: null,
+    resultCount: 0,
+    sortBy: "averageRP",
+    explorationDepth: 0,
+  });
+
   React.useEffect(() => {
     if (loading || selectedAllies.length === 0 || recommendations.length === 0) return;
     const key = `${selectedAllies[0] ?? "_"}|${selectedAllies[1] ?? "_"}|${sortBy}`;
     if (lastViewedKeyRef.current === key) return;
+    const previousKey = lastViewedKeyRef.current;
+    const previousPairKey = previousKey?.split("|").slice(0, 2).join("|") ?? null;
+    const currentPairKey = `${selectedAllies[0] ?? "_"}|${selectedAllies[1] ?? "_"}`;
+    const source =
+      previousKey === null && typeof window !== "undefined" && window.location.search
+        ? "url_restore"
+        : previousPairKey === currentPairKey
+          ? "sort_change"
+          : "filter_change";
     lastViewedKeyRef.current = key;
+    explorationDepthRef.current += 1;
+    funnelStateRef.current = {
+      viewed: true,
+      openedDetail: false,
+      ally1Code: selectedAllies[0] ?? null,
+      ally2Code: selectedAllies[1] ?? null,
+      resultCount: recommendations.length,
+      sortBy: sortBy as SynergySortBy,
+      explorationDepth: explorationDepthRef.current,
+    };
     analytics.synergyResultViewed({
       ally1Code: selectedAllies[0] ?? null,
       ally2Code: selectedAllies[1] ?? null,
@@ -237,7 +356,46 @@ export function SynergyResults({ compact = false }: { compact?: boolean }) {
       patch: "",
       isWeaponScope: false,
     });
+    analytics.synergyExplorationAdvanced({
+      ally1Code: selectedAllies[0] ?? null,
+      ally2Code: selectedAllies[1] ?? null,
+      resultCount: recommendations.length,
+      sortBy: sortBy as SynergySortBy,
+      explorationDepth: explorationDepthRef.current,
+      isWeaponScope: false,
+      source,
+    });
   }, [loading, selectedAllies, sortBy, recommendations]);
+
+  const emitFunnelExit = React.useCallback(() => {
+    const state = funnelStateRef.current;
+    if (!state.viewed) return;
+    analytics.synergyFunnelExited({
+      ally1Code: state.ally1Code,
+      ally2Code: state.ally2Code,
+      resultCount: state.resultCount,
+      sortBy: state.sortBy,
+      explorationDepth: state.explorationDepth,
+      openedDetail: state.openedDetail,
+      isWeaponScope: false,
+    });
+    state.viewed = false;
+  }, []);
+
+  React.useEffect(() => {
+    const handlePageHide = () => emitFunnelExit();
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") emitFunnelExit();
+    };
+
+    window.addEventListener("pagehide", handlePageHide);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      emitFunnelExit();
+      window.removeEventListener("pagehide", handlePageHide);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [emitFunnelExit]);
 
   return (
     <>
@@ -247,10 +405,7 @@ export function SynergyResults({ compact = false }: { compact?: boolean }) {
           {SORT_OPTIONS.map(({ value, labelKey }) => (
             <button
               key={value}
-              onClick={() => {
-                setSortBy(value);
-                analytics.synergySortChanged(value);
-              }}
+              onClick={() => updateSortBy(value)}
               className="dashboard-tab min-h-[30px] px-2.5 py-1 text-xs"
               data-active={sortBy === value ? "true" : undefined}
             >
@@ -397,7 +552,10 @@ export function SynergyResults({ compact = false }: { compact?: boolean }) {
                   isTopResult={i < 3}
                   compact={compact}
                   priorityImages={i < 5}
+                  prefetchOnViewport={i < 4}
+                  onPrefetchAnalysis={prefetchAnalysis}
                   onNavigateAnalysis={(code) => {
+                    funnelStateRef.current.openedDetail = true;
                     analytics.synergyRecommendationClicked({
                       ally1Code: selectedAllies[0] ?? null,
                       ally2Code: selectedAllies[1] ?? null,
@@ -405,7 +563,7 @@ export function SynergyResults({ compact = false }: { compact?: boolean }) {
                       pickedRank: i + 1,
                       sortBy: sortBy as SynergySortBy,
                     });
-                    router.push(`/character/${code}`);
+                    router.push(withCurrentRouteLocale(pathname, `/character/${code}`));
                   }}
                 />
               ))}

--- a/frontend/src/components/features/synergy/constants.ts
+++ b/frontend/src/components/features/synergy/constants.ts
@@ -34,3 +34,7 @@ export const SORT_OPTIONS: {
   { value: "averageRank", label: "평균 순위", labelKey: "averageRank" },
   { value: "totalGames", label: "게임 수", labelKey: "totalGames" },
 ];
+
+export function parseSortByParam(value: string | null): SortBy {
+  return SORT_OPTIONS.some((option) => option.value === value) ? (value as SortBy) : "averageRP";
+}

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -41,6 +41,7 @@ export type Source =
   | "external";
 
 export type SynergySortBy = "averageRP" | "winRate" | "averageRank" | "totalGames";
+export type SynergyPrefetchTrigger = "hover" | "viewport";
 
 export type SessionSource = "organic_search" | "community" | "direct" | "social" | "internal";
 
@@ -217,6 +218,41 @@ export const analytics = {
     sortBy: SynergySortBy;
   }) {
     track("synergy_recommendation_clicked", { ...args, source: "synergy" as const });
+  },
+
+  /** 시너지 탐색 세션 내 조건 탐색 깊이 증가 */
+  synergyExplorationAdvanced(args: {
+    ally1Code: number | null;
+    ally2Code: number | null;
+    resultCount: number;
+    sortBy: SynergySortBy;
+    explorationDepth: number;
+    isWeaponScope: boolean;
+    source: "url_restore" | "filter_change" | "sort_change";
+  }) {
+    track("synergy_exploration_advanced", args);
+  },
+
+  /** 결과를 본 뒤 상세 조회 없이 떠나는 비율 계산용 종료 이벤트 */
+  synergyFunnelExited(args: {
+    ally1Code: number | null;
+    ally2Code: number | null;
+    resultCount: number;
+    sortBy: SynergySortBy;
+    explorationDepth: number;
+    openedDetail: boolean;
+    isWeaponScope: boolean;
+  }) {
+    track("synergy_funnel_exited", args);
+  },
+
+  /** 추천 카드 상세 라우트 prefetch */
+  synergyRecommendationPrefetched(args: {
+    pickedCode: number;
+    pickedRank: number;
+    trigger: SynergyPrefetchTrigger;
+  }) {
+    track("synergy_recommendation_prefetched", { ...args, source: "synergy" as const });
   },
 
   /**


### PR DESCRIPTION
## 변경 사항
  - 정렬 상태를 URL query로 공유/복원할 수 있도록 추가
  - 정렬 변경 시 API 재요청 없이 클라이언트에서만 재정렬
  - 추천 카드 hover/viewport 진입 시 캐릭터 상세 페이지 prefetch
  - 시너지 탐색/이탈/prefetch analytics 이벤트 추가
  - 상세 조합 결과 리스트 렌더링 최적화


## 테스트 결과 (테스트를 했으면)
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.