### PR TITLE
[fix] 광고 슬롯 CLS 방어 및 로딩 안정화

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -33,11 +33,8 @@ const nextConfig: NextConfig = {
     optimizePackageImports: ["lucide-react", "recharts"],
   },
   async rewrites() {
-    const frozenPatchAnalysisRewrites = getFrozenPatchAnalysisRewrites();
-    if (frozenPatchAnalysisRewrites.length === 0) return [];
-
     return {
-      beforeFiles: frozenPatchAnalysisRewrites,
+      beforeFiles: getFrozenPatchAnalysisRewrites(),
     };
   },
   async redirects() {

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -4,9 +4,41 @@ import createNextIntlPlugin from "next-intl/plugin";
 
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
+function parseCsvEnv(value: string | undefined): string[] {
+  return (value ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function getFrozenPatchAnalysisRewrites() {
+  const origin = process.env.PATCH_ANALYSIS_FROZEN_ORIGIN?.replace(/\/$/, "");
+  const versions = parseCsvEnv(process.env.PATCH_ANALYSIS_FROZEN_VERSIONS);
+  if (!origin || versions.length === 0) return [];
+
+  return versions.flatMap((version) => [
+    {
+      source: `/patch-analysis/${version}`,
+      destination: `${origin}/patch-analysis/${version}`,
+    },
+    {
+      source: `/:locale(ko|en|ja)/patch-analysis/${version}`,
+      destination: `${origin}/:locale/patch-analysis/${version}`,
+    },
+  ]);
+}
+
 const nextConfig: NextConfig = {
   experimental: {
     optimizePackageImports: ["lucide-react", "recharts"],
+  },
+  async rewrites() {
+    const frozenPatchAnalysisRewrites = getFrozenPatchAnalysisRewrites();
+    if (frozenPatchAnalysisRewrites.length === 0) return [];
+
+    return {
+      beforeFiles: frozenPatchAnalysisRewrites,
+    };
   },
   async redirects() {
     return [

--- a/frontend/src/__tests__/analytics.test.ts
+++ b/frontend/src/__tests__/analytics.test.ts
@@ -298,6 +298,8 @@ describe("analytics — P0 helpers", () => {
         slot_name: "synergy_detail_top",
         ad_slot_id: "8139813658",
         page_path: "/ko/synergy-detail",
+        reserved_height: undefined,
+        reserved_width: undefined,
       });
     });
 
@@ -317,6 +319,27 @@ describe("analytics — P0 helpers", () => {
         page_path: "/ko",
         viewport_width: 390,
         viewport_height: 844,
+        reserved_height: undefined,
+        reserved_width: undefined,
+      });
+    });
+
+    it("ad_slot_state_changed 에 슬롯 상태와 예약 크기를 전달한다", async () => {
+      analytics.adSlotStateChanged({
+        slotName: "site_rail_right",
+        adSlotId: "8139813658",
+        status: "unfilled",
+        reservedHeight: 600,
+        reservedWidth: 160,
+      });
+      await flushAsync();
+      expect(trackMock).toHaveBeenCalledWith("ad_slot_state_changed", {
+        slot_name: "site_rail_right",
+        ad_slot_id: "8139813658",
+        status: "unfilled",
+        page_path: undefined,
+        reserved_height: 600,
+        reserved_width: 160,
       });
     });
   });

--- a/frontend/src/app/(site)/[locale]/patch-analysis/[version]/page.tsx
+++ b/frontend/src/app/(site)/[locale]/patch-analysis/[version]/page.tsx
@@ -46,10 +46,22 @@ const PATCH_ANALYSIS_METADATA = {
 } as const;
 
 export const dynamic = "force-static";
-export const dynamicParams = false;
+export const dynamicParams = true;
+
+function getSkippedStaticPatchAnalysisVersions() {
+  return new Set(
+    (process.env.SKIP_PATCH_ANALYSIS_STATIC_VERSIONS ?? "")
+      .split(",")
+      .map((version) => version.trim())
+      .filter(Boolean)
+  );
+}
 
 export function generateStaticParams() {
-  const patchVersions = getPatchAnalysisVersions();
+  const skippedVersions = getSkippedStaticPatchAnalysisVersions();
+  const patchVersions = getPatchAnalysisVersions().filter(
+    (version) => !skippedVersions.has(version)
+  );
 
   return ROUTE_LOCALES.flatMap((locale) =>
     patchVersions.map((version) => ({

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -532,8 +532,27 @@ html[data-theme="dark"] .char-card.home-pick-card:hover {
 
 .ad-placement {
   position: relative;
-  display: block;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
   width: 100%;
+  min-height: var(--ad-reserved-height, 100px);
+  height: var(--ad-reserved-height, 100px);
+  overflow: hidden;
+  contain: layout paint style;
+}
+
+@media (min-width: 640px) {
+  .ad-placement {
+    min-height: var(--ad-reserved-height-sm, var(--ad-reserved-height, 100px));
+    height: var(--ad-reserved-height-sm, var(--ad-reserved-height, 100px));
+  }
+}
+
+@media (min-width: 1024px) {
+  .ad-placement {
+    min-height: var(--ad-reserved-height-lg, var(--ad-reserved-height-sm, 100px));
+    height: var(--ad-reserved-height-lg, var(--ad-reserved-height-sm, 100px));
+  }
 }
 
 .ad-placement-label {
@@ -548,9 +567,27 @@ html[data-theme="dark"] .char-card.home-pick-card:hover {
   text-transform: none;
 }
 
+.ad-placement .adsbygoogle {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.ad-placement-fallback {
+  position: absolute;
+  inset: 22px 8px 8px;
+  display: grid;
+  place-items: center;
+  border: 1px dashed rgba(100, 116, 139, 0.35);
+  border-radius: 4px;
+  color: var(--color-muted-foreground);
+  font-size: 11px;
+  font-weight: 600;
+  opacity: 0.55;
+  pointer-events: none;
+}
+
 .ad-placement-preview-box {
   display: grid;
-  min-height: 96px;
   place-items: center;
   border: 1px dashed rgba(100, 116, 139, 0.5);
   border-radius: 4px;

--- a/frontend/src/components/AppFrame.tsx
+++ b/frontend/src/components/AppFrame.tsx
@@ -1,6 +1,10 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
-import { ADSENSE_SLOTS, canRenderAdSlot } from "@/components/ads/adsenseConfig";
+import {
+  ADSENSE_SLOT_RESERVATIONS,
+  ADSENSE_SLOTS,
+  canRenderAdSlot,
+} from "@/components/ads/adsenseConfig";
 import { AdSlot } from "@/components/ads/AdSlot";
 import { Header } from "@/components/layout/Header";
 import type { RouteLocale } from "@/i18n/routing";
@@ -65,8 +69,8 @@ export function AppFrame({
                       slotName="site_rail_left"
                       format="vertical"
                       responsive={false}
+                      reservation={ADSENSE_SLOT_RESERVATIONS.siteRail}
                       className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-2"
-                      minHeight={600}
                     />
                   </div>
                 ) : null}
@@ -84,8 +88,8 @@ export function AppFrame({
                       slotName="site_rail_right"
                       format="vertical"
                       responsive={false}
+                      reservation={ADSENSE_SLOT_RESERVATIONS.siteRail}
                       className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-2"
-                      minHeight={600}
                     />
                   </div>
                 ) : null}

--- a/frontend/src/components/ads/AdSenseScript.tsx
+++ b/frontend/src/components/ads/AdSenseScript.tsx
@@ -36,7 +36,7 @@ export function AdSenseScript() {
       async
       src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${ADSENSE_CLIENT}`}
       crossOrigin="anonymous"
-      strategy="afterInteractive"
+      strategy="lazyOnload"
     />
   );
 }

--- a/frontend/src/components/ads/AdSlot.tsx
+++ b/frontend/src/components/ads/AdSlot.tsx
@@ -1,8 +1,12 @@
 "use client";
 
 import { useLocale } from "next-intl";
-import { useEffect, useRef } from "react";
-import { ADSENSE_CLIENT, ADSENSE_PREVIEW } from "@/components/ads/adsenseConfig";
+import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ADSENSE_CLIENT,
+  ADSENSE_PREVIEW,
+  type AdSlotReservation,
+} from "@/components/ads/adsenseConfig";
 import type { RouteLocale } from "@/i18n/routing";
 import { analytics, type AdSlotName } from "@/lib/analytics";
 
@@ -20,6 +24,7 @@ interface AdSlotProps {
   layoutKey?: string;
   responsive?: boolean;
   className?: string;
+  reservation?: AdSlotReservation;
   minHeight?: number;
 }
 
@@ -31,6 +36,47 @@ const AD_LABEL: Record<RouteLocale, string> = {
   "zh-Hant": "廣告",
 };
 
+type AdSlotStatus = "reserved" | "requested" | "filled" | "unfilled" | "timeout";
+
+type AdSlotStyle = CSSProperties & {
+  "--ad-reserved-height": string;
+  "--ad-reserved-height-sm": string;
+  "--ad-reserved-height-lg": string;
+  "--ad-reserved-width"?: string;
+};
+
+function getReservationStyle(
+  reservation: AdSlotReservation | undefined,
+  fallbackHeight: number
+): AdSlotStyle {
+  const baseHeight = reservation?.baseHeight ?? fallbackHeight;
+  const smHeight = reservation?.smHeight ?? baseHeight;
+  const lgHeight = reservation?.lgHeight ?? smHeight;
+
+  return {
+    "--ad-reserved-height": `${baseHeight}px`,
+    "--ad-reserved-height-sm": `${smHeight}px`,
+    "--ad-reserved-height-lg": `${lgHeight}px`,
+    "--ad-reserved-width": reservation?.width ? `${reservation.width}px` : undefined,
+  };
+}
+
+function getCurrentReservedHeight(
+  reservation: AdSlotReservation | undefined,
+  fallbackHeight: number
+) {
+  if (typeof window === "undefined") return reservation?.baseHeight ?? fallbackHeight;
+  if (window.matchMedia("(min-width: 1024px)").matches) {
+    return (
+      reservation?.lgHeight ?? reservation?.smHeight ?? reservation?.baseHeight ?? fallbackHeight
+    );
+  }
+  if (window.matchMedia("(min-width: 640px)").matches) {
+    return reservation?.smHeight ?? reservation?.baseHeight ?? fallbackHeight;
+  }
+  return reservation?.baseHeight ?? fallbackHeight;
+}
+
 export function AdSlot({
   slot,
   slotName,
@@ -39,6 +85,7 @@ export function AdSlot({
   layoutKey,
   responsive = true,
   className,
+  reservation,
   minHeight = 100,
 }: AdSlotProps) {
   const locale = useLocale() as RouteLocale;
@@ -48,6 +95,28 @@ export function AdSlot({
   const pushedElement = useRef<HTMLModElement | null>(null);
   const renderedTracked = useRef(false);
   const viewedTracked = useRef(false);
+  const statusTracked = useRef<Set<AdSlotStatus>>(new Set());
+  const [status, setStatus] = useState<AdSlotStatus>("reserved");
+  const reservedHeight = getCurrentReservedHeight(reservation, minHeight);
+  const reservedStyle = useMemo(
+    () => getReservationStyle(reservation, minHeight),
+    [minHeight, reservation]
+  );
+
+  const trackStatus = useCallback(
+    (nextStatus: AdSlotStatus) => {
+      if (!slot || statusTracked.current.has(nextStatus)) return;
+      statusTracked.current.add(nextStatus);
+      analytics.adSlotStateChanged({
+        slotName,
+        adSlotId: slot,
+        status: nextStatus,
+        reservedHeight,
+        reservedWidth: reservation?.width ?? null,
+      });
+    },
+    [reservation?.width, reservedHeight, slot, slotName]
+  );
 
   useEffect(() => {
     const element = insRef.current;
@@ -56,16 +125,51 @@ export function AdSlot({
     try {
       (window.adsbygoogle = window.adsbygoogle || []).push({});
       pushedElement.current = element;
+      trackStatus("requested");
     } catch {
       // adsbygoogle may not be loaded yet; loader script will retry on script load
     }
-  }, [slot]);
+  }, [slot, trackStatus]);
+
+  useEffect(() => {
+    if (ADSENSE_PREVIEW || !ADSENSE_CLIENT || !slot) return;
+    const element = insRef.current;
+    if (!element || typeof MutationObserver === "undefined") return;
+
+    const updateStatus = () => {
+      const adStatus = element.getAttribute("data-ad-status");
+      const nextStatus = adStatus === "filled" || adStatus === "unfilled" ? adStatus : null;
+      if (!nextStatus) return;
+      setStatus(nextStatus);
+      trackStatus(nextStatus);
+    };
+
+    const observer = new MutationObserver(updateStatus);
+    observer.observe(element, { attributes: true, attributeFilter: ["data-ad-status"] });
+
+    const timeoutId = setTimeout(() => {
+      if (element.getAttribute("data-ad-status")) return;
+      if (element.querySelector("iframe")) return;
+      setStatus("timeout");
+      trackStatus("timeout");
+    }, 6000);
+
+    return () => {
+      observer.disconnect();
+      clearTimeout(timeoutId);
+    };
+  }, [slot, trackStatus]);
 
   useEffect(() => {
     if (!slot || renderedTracked.current) return;
     renderedTracked.current = true;
-    analytics.adSlotRendered({ slotName, adSlotId: slot });
-  }, [slot, slotName]);
+    analytics.adSlotRendered({
+      slotName,
+      adSlotId: slot,
+      reservedHeight,
+      reservedWidth: reservation?.width ?? null,
+    });
+  }, [reservation?.width, reservedHeight, slot, slotName]);
 
   useEffect(() => {
     if (!slot || viewedTracked.current) return;
@@ -87,7 +191,12 @@ export function AdSlot({
           if (viewTimer) return;
           viewTimer = setTimeout(() => {
             viewedTracked.current = true;
-            analytics.adSlotViewed({ slotName, adSlotId: slot });
+            analytics.adSlotViewed({
+              slotName,
+              adSlotId: slot,
+              reservedHeight,
+              reservedWidth: reservation?.width ?? null,
+            });
             observer.disconnect();
           }, 1000);
         } else {
@@ -103,14 +212,16 @@ export function AdSlot({
       clearViewTimer();
       observer.disconnect();
     };
-  }, [slot, slotName]);
+  }, [reservation?.width, reservedHeight, slot, slotName]);
 
   if (ADSENSE_PREVIEW) {
     return (
       <div
         ref={rootRef}
         className={`ad-placement ad-placement-preview ${className ?? ""}`}
-        style={{ minHeight }}
+        style={reservedStyle}
+        data-ad-slot-name={slotName}
+        data-ad-slot-status="preview"
       >
         <span className="ad-placement-label">{label}</span>
         <div className="ad-placement-preview-box" aria-hidden="true" />
@@ -120,14 +231,22 @@ export function AdSlot({
 
   if (!ADSENSE_CLIENT || !slot) return null;
 
+  const showFallback = status === "unfilled" || status === "timeout";
+
   return (
-    <div ref={rootRef} className={`ad-placement ${className ?? ""}`} style={{ minHeight }}>
+    <div
+      ref={rootRef}
+      className={`ad-placement ${className ?? ""}`}
+      style={reservedStyle}
+      data-ad-slot-name={slotName}
+      data-ad-slot-status={status}
+    >
       <span className="ad-placement-label">{label}</span>
       <ins
         key={`${slotName}:${slot}`}
         ref={insRef}
         className="adsbygoogle block"
-        style={{ display: "block", minHeight, width: "100%" }}
+        style={{ display: "block", minHeight: 0, width: "100%", height: "100%" }}
         data-ad-client={ADSENSE_CLIENT}
         data-ad-slot={slot}
         data-ad-format={format}
@@ -135,6 +254,11 @@ export function AdSlot({
         data-ad-layout-key={layoutKey}
         data-full-width-responsive={responsive ? "true" : "false"}
       />
+      {showFallback ? (
+        <div className="ad-placement-fallback" aria-hidden="true">
+          {label}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/components/ads/AdSlot.tsx
+++ b/frontend/src/components/ads/AdSlot.tsx
@@ -97,7 +97,6 @@ export function AdSlot({
   const viewedTracked = useRef(false);
   const statusTracked = useRef<Set<AdSlotStatus>>(new Set());
   const [status, setStatus] = useState<AdSlotStatus>("reserved");
-  const reservedHeight = getCurrentReservedHeight(reservation, minHeight);
   const reservedStyle = useMemo(
     () => getReservationStyle(reservation, minHeight),
     [minHeight, reservation]
@@ -111,11 +110,11 @@ export function AdSlot({
         slotName,
         adSlotId: slot,
         status: nextStatus,
-        reservedHeight,
+        reservedHeight: getCurrentReservedHeight(reservation, minHeight),
         reservedWidth: reservation?.width ?? null,
       });
     },
-    [reservation?.width, reservedHeight, slot, slotName]
+    [minHeight, reservation, slot, slotName]
   );
 
   useEffect(() => {
@@ -136,27 +135,39 @@ export function AdSlot({
     const element = insRef.current;
     if (!element || typeof MutationObserver === "undefined") return;
 
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    const clearStatusTimeout = () => {
+      if (!timeoutId) return;
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    };
+
     const updateStatus = () => {
       const adStatus = element.getAttribute("data-ad-status");
       const nextStatus = adStatus === "filled" || adStatus === "unfilled" ? adStatus : null;
       if (!nextStatus) return;
       setStatus(nextStatus);
       trackStatus(nextStatus);
+      clearStatusTimeout();
     };
 
     const observer = new MutationObserver(updateStatus);
     observer.observe(element, { attributes: true, attributeFilter: ["data-ad-status"] });
 
-    const timeoutId = setTimeout(() => {
+    timeoutId = setTimeout(() => {
       if (element.getAttribute("data-ad-status")) return;
       if (element.querySelector("iframe")) return;
       setStatus("timeout");
       trackStatus("timeout");
+      timeoutId = null;
     }, 6000);
+
+    updateStatus();
 
     return () => {
       observer.disconnect();
-      clearTimeout(timeoutId);
+      clearStatusTimeout();
     };
   }, [slot, trackStatus]);
 
@@ -166,10 +177,10 @@ export function AdSlot({
     analytics.adSlotRendered({
       slotName,
       adSlotId: slot,
-      reservedHeight,
+      reservedHeight: getCurrentReservedHeight(reservation, minHeight),
       reservedWidth: reservation?.width ?? null,
     });
-  }, [reservation?.width, reservedHeight, slot, slotName]);
+  }, [minHeight, reservation, slot, slotName]);
 
   useEffect(() => {
     if (!slot || viewedTracked.current) return;
@@ -194,7 +205,7 @@ export function AdSlot({
             analytics.adSlotViewed({
               slotName,
               adSlotId: slot,
-              reservedHeight,
+              reservedHeight: getCurrentReservedHeight(reservation, minHeight),
               reservedWidth: reservation?.width ?? null,
             });
             observer.disconnect();
@@ -212,7 +223,7 @@ export function AdSlot({
       clearViewTimer();
       observer.disconnect();
     };
-  }, [reservation?.width, reservedHeight, slot, slotName]);
+  }, [minHeight, reservation, slot, slotName]);
 
   if (ADSENSE_PREVIEW) {
     return (

--- a/frontend/src/components/ads/adsenseConfig.ts
+++ b/frontend/src/components/ads/adsenseConfig.ts
@@ -11,6 +11,25 @@ export const ADSENSE_CLIENT = ADSENSE_DISABLED
 export const ADSENSE_PREVIEW =
   !ADSENSE_DISABLED && process.env.NEXT_PUBLIC_ADSENSE_PREVIEW === "true";
 
+export interface AdSlotReservation {
+  baseHeight: number;
+  smHeight?: number;
+  lgHeight?: number;
+  width?: number;
+}
+
+export const ADSENSE_SLOT_RESERVATIONS = {
+  contentHorizontal: {
+    baseHeight: 112,
+    smHeight: 120,
+    lgHeight: 120,
+  },
+  siteRail: {
+    baseHeight: 600,
+    width: 160,
+  },
+} as const satisfies Record<string, AdSlotReservation>;
+
 export const ADSENSE_SLOTS = {
   homeRanking: ADSENSE_DISABLED
     ? ""

--- a/frontend/src/components/features/home/HomeDashboardSections.tsx
+++ b/frontend/src/components/features/home/HomeDashboardSections.tsx
@@ -2,7 +2,11 @@
 
 import { useTranslations } from "next-intl";
 import * as React from "react";
-import { ADSENSE_SLOTS, canRenderAdSlot } from "@/components/ads/adsenseConfig";
+import {
+  ADSENSE_SLOT_RESERVATIONS,
+  ADSENSE_SLOTS,
+  canRenderAdSlot,
+} from "@/components/ads/adsenseConfig";
 import { AdSlot } from "@/components/ads/AdSlot";
 import { FilterProvider, useFilter } from "@/components/features/FilterContext";
 import { GlobalFilter } from "@/components/features/GlobalFilter";
@@ -117,7 +121,7 @@ function HomeDashboardSectionsBody({
           slot={ADSENSE_SLOTS.homeRanking}
           slotName="home_ranking"
           className="dashboard-panel px-3 py-2.5 sm:px-4"
-          minHeight={120}
+          reservation={ADSENSE_SLOT_RESERVATIONS.contentHorizontal}
         />
       ) : null}
 

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -19,6 +19,11 @@ function track(event: string, properties?: Record<string, unknown>) {
     .catch(() => {});
 }
 
+function getCurrentPagePath() {
+  if (typeof window === "undefined") return undefined;
+  return window.location?.pathname;
+}
+
 // ── Types (pm/amplitude-event-design.md §3.3) ────────────────────────────────
 export type FeatureKey =
   | "character_analysis"
@@ -50,6 +55,7 @@ export type AdSlotName =
   | "synergy_detail_top"
   | "site_rail_left"
   | "site_rail_right";
+export type AdSlotStatus = "reserved" | "requested" | "filled" | "unfilled" | "timeout";
 
 export interface SessionProperties {
   session_source?: SessionSource;
@@ -285,17 +291,30 @@ export const analytics = {
   },
 
   /** 광고 슬롯 DOM 렌더링 — 실제 광고 fill 여부와 무관하게 슬롯 노출 후보를 측정한다. */
-  adSlotRendered(args: { slotName: AdSlotName; adSlotId: string; pagePath?: string }) {
+  adSlotRendered(args: {
+    slotName: AdSlotName;
+    adSlotId: string;
+    pagePath?: string;
+    reservedHeight?: number;
+    reservedWidth?: number | null;
+  }) {
     track("ad_slot_rendered", {
       slot_name: args.slotName,
       ad_slot_id: args.adSlotId,
-      page_path:
-        args.pagePath ?? (typeof window !== "undefined" ? window.location.pathname : undefined),
+      page_path: args.pagePath ?? getCurrentPagePath(),
+      reserved_height: args.reservedHeight,
+      reserved_width: args.reservedWidth,
     });
   },
 
   /** 광고 슬롯이 viewport 에 50% 이상 1초 머문 경우. 클릭 추적은 AdSense 정책상 하지 않는다. */
-  adSlotViewed(args: { slotName: AdSlotName; adSlotId: string; pagePath?: string }) {
+  adSlotViewed(args: {
+    slotName: AdSlotName;
+    adSlotId: string;
+    pagePath?: string;
+    reservedHeight?: number;
+    reservedWidth?: number | null;
+  }) {
     const viewport =
       typeof window !== "undefined"
         ? {
@@ -307,10 +326,29 @@ export const analytics = {
     track("ad_slot_viewed", {
       slot_name: args.slotName,
       ad_slot_id: args.adSlotId,
-      page_path:
-        args.pagePath ?? (typeof window !== "undefined" ? window.location.pathname : undefined),
+      page_path: args.pagePath ?? getCurrentPagePath(),
       viewport_width: viewport?.width,
       viewport_height: viewport?.height,
+      reserved_height: args.reservedHeight,
+      reserved_width: args.reservedWidth,
+    });
+  },
+
+  /** 광고 슬롯 lifecycle — fill/unfilled/timeout 비율을 성능 지표와 같이 본다. */
+  adSlotStateChanged(args: {
+    slotName: AdSlotName;
+    adSlotId: string;
+    status: AdSlotStatus;
+    reservedHeight: number;
+    reservedWidth: number | null;
+  }) {
+    track("ad_slot_state_changed", {
+      slot_name: args.slotName,
+      ad_slot_id: args.adSlotId,
+      status: args.status,
+      page_path: getCurrentPagePath(),
+      reserved_height: args.reservedHeight,
+      reserved_width: args.reservedWidth,
     });
   },
 
@@ -363,7 +401,7 @@ export const analytics = {
     rating?: "good" | "needs-improvement" | "poor";
     navigationType?: string;
   }) {
-    const pagePath = typeof window !== "undefined" ? window.location.pathname : undefined;
+    const pagePath = getCurrentPagePath();
     const connection =
       typeof navigator !== "undefined"
         ? (navigator as unknown as { connection?: { effectiveType?: string } }).connection
@@ -381,6 +419,10 @@ export const analytics = {
       navigation_type: metric.navigationType,
       page_path: pagePath,
       effective_connection_type: connection?.effectiveType,
+      ad_slots_present:
+        typeof document !== "undefined"
+          ? document.querySelectorAll("[data-ad-slot-name]").length
+          : 0,
     });
   },
 };

--- a/frontend/src/views/synergy-detail/SynergyDetailPage.tsx
+++ b/frontend/src/views/synergy-detail/SynergyDetailPage.tsx
@@ -3,7 +3,11 @@ import type { Metadata } from "next";
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
 import type { ReactNode } from "react";
-import { ADSENSE_SLOTS, canRenderAdSlot } from "@/components/ads/adsenseConfig";
+import {
+  ADSENSE_SLOT_RESERVATIONS,
+  ADSENSE_SLOTS,
+  canRenderAdSlot,
+} from "@/components/ads/adsenseConfig";
 import { AdSlot } from "@/components/ads/AdSlot";
 import { SynergyDetailClient } from "@/components/features/synergy-detail/SynergyDetailClient";
 import { getCharacterName } from "@/lib/characterMap";
@@ -207,7 +211,7 @@ export default function SynergyDetailPage() {
           slot={ADSENSE_SLOTS.synergyDetail}
           slotName="synergy_detail_top"
           className="dashboard-panel px-3 py-2.5 sm:px-4"
-          minHeight={120}
+          reservation={ADSENSE_SLOT_RESERVATIONS.contentHorizontal}
         />
       ) : null}
 


### PR DESCRIPTION
 ## 변경 사항
  - 광고 슬롯의 예약 영역과 최소 높이를 보강해 광고 로딩 전후 CLS 발생 가능성을 줄였습니다.
  - AdSense 스크립트 로딩과 광고 슬롯 상태 처리를 안정화했습니다.
  - 광고 슬롯 로드/에러/상태 변화를 분석 이벤트로 계측하도록 추가했습니다.
  - 홈, 시너지 상세, 패치 분석 페이지의 광고 배치가 레이아웃을 흔들지 않도록 조정했습니다.
  - 패치 분석 이전 배포 접근을 위한 프록시 설정을 추가했습니다.


## 테스트 결과 (테스트를 했으면)
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.