### PR TITLE
[refactor] initialL10n 전체 직렬화 제거 및 compact seed 전환

### DIFF
--- a/frontend/src/__tests__/serverL10n.test.ts
+++ b/frontend/src/__tests__/serverL10n.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { SUPPORTED_LANGUAGES } from "@/lib/detectLanguage";
+import { extractL10nSeed, loadL10nSeed } from "@/lib/serverL10n";
+
+describe("l10n seed", () => {
+  it("keeps only names required for the initial paint", () => {
+    expect(
+      extractL10nSeed({
+        "Character/Name/1": "Jackie",
+        "WeaponType/Axe": "Axe",
+        "Trait/Name/7000201": "Vigor",
+        "Item/Name/101101": "Scissors",
+        "Skill/Name/1001000": "Chain Saw Murderer",
+        "Trait/Description/7000201": "Ignored",
+      })
+    ).toEqual({
+      "Character/Name/1": "Jackie",
+      "WeaponType/Axe": "Axe",
+      "Trait/Name/7000201": "Vigor",
+    });
+  });
+
+  it.each(SUPPORTED_LANGUAGES)("loads a compact %s seed", (language) => {
+    const seed = loadL10nSeed(language);
+
+    expect(seed).toBeDefined();
+    expect(Object.keys(seed ?? {})).not.toHaveLength(0);
+    expect(Buffer.byteLength(JSON.stringify(seed))).toBeLessThan(20_000);
+    expect(
+      Object.keys(seed ?? {}).every((key) =>
+        ["Character/Name/", "WeaponType/", "Trait/Name/"].some((prefix) => key.startsWith(prefix))
+      )
+    ).toBe(true);
+  });
+});

--- a/frontend/src/app/(default)/layout.tsx
+++ b/frontend/src/app/(default)/layout.tsx
@@ -11,7 +11,7 @@ import { getStatsPatchVersions } from "@/data/patch-notes";
 import { DEFAULT_ROUTE_LOCALE } from "@/i18n/routing";
 import { DEFAULT_LANGUAGE } from "@/lib/detectLanguage";
 import { getPatchAnalysisVersions } from "@/lib/patchAnalysis";
-import { loadL10nRecord } from "@/lib/serverL10n";
+import { loadL10nSeed } from "@/lib/serverL10n";
 import { buildDefaultSiteMetadata, buildWebsiteStructuredData } from "@/lib/siteMetadata";
 import { HTML_LANG_BY_LANGUAGE, loadIntlMessages } from "@/lib/staticIntl";
 
@@ -21,7 +21,7 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function DefaultLayout({ children }: { children: ReactNode }) {
   const initialMessages = await loadIntlMessages(DEFAULT_LANGUAGE);
-  const initialL10n = loadL10nRecord(DEFAULT_LANGUAGE);
+  const initialL10nSeed = loadL10nSeed(DEFAULT_LANGUAGE);
   const structuredData = await buildWebsiteStructuredData(DEFAULT_LANGUAGE, DEFAULT_ROUTE_LOCALE);
   const currentPatch = getStatsPatchVersions()[0] ?? "";
   const patchAnalysisPatch = getPatchAnalysisVersions()[0] ?? "";
@@ -34,7 +34,7 @@ export default async function DefaultLayout({ children }: { children: ReactNode 
       </head>
       <body>
         <L10nProvider
-          initialL10n={initialL10n}
+          initialL10nSeed={initialL10nSeed}
           initialMessages={initialMessages}
           initialLanguage={DEFAULT_LANGUAGE}
         >

--- a/frontend/src/app/(misc)/layout.tsx
+++ b/frontend/src/app/(misc)/layout.tsx
@@ -7,7 +7,7 @@ import { RootDocumentExtras } from "@/components/RootDocumentExtras";
 import { ThemeInitScript } from "@/components/ThemeInitScript";
 import { DEFAULT_LANGUAGE } from "@/lib/detectLanguage";
 import { geistSans } from "@/lib/geistFont";
-import { loadL10nRecord } from "@/lib/serverL10n";
+import { loadL10nSeed } from "@/lib/serverL10n";
 import { HTML_LANG_BY_LANGUAGE, loadIntlMessages } from "@/lib/staticIntl";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -25,7 +25,7 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function MiscLayout({ children }: { children: ReactNode }) {
   const initialMessages = await loadIntlMessages(DEFAULT_LANGUAGE);
-  const initialL10n = loadL10nRecord(DEFAULT_LANGUAGE);
+  const initialL10nSeed = loadL10nSeed(DEFAULT_LANGUAGE);
 
   return (
     <html
@@ -39,7 +39,7 @@ export default async function MiscLayout({ children }: { children: ReactNode }) 
       </head>
       <body>
         <L10nProvider
-          initialL10n={initialL10n}
+          initialL10nSeed={initialL10nSeed}
           initialMessages={initialMessages}
           initialLanguage={DEFAULT_LANGUAGE}
         >

--- a/frontend/src/app/(site)/[locale]/layout.tsx
+++ b/frontend/src/app/(site)/[locale]/layout.tsx
@@ -13,7 +13,7 @@ import { getStatsPatchVersions } from "@/data/patch-notes";
 import { LANGUAGE_BY_ROUTE_LOCALE, ROUTE_LOCALES, isRouteLocale } from "@/i18n/routing";
 import { geistSans } from "@/lib/geistFont";
 import { getPatchAnalysisVersions } from "@/lib/patchAnalysis";
-import { loadL10nRecord } from "@/lib/serverL10n";
+import { loadL10nSeed } from "@/lib/serverL10n";
 import { buildSiteMetadata, buildWebsiteStructuredData } from "@/lib/siteMetadata";
 import { HTML_LANG_BY_LANGUAGE, loadIntlMessages } from "@/lib/staticIntl";
 
@@ -47,7 +47,7 @@ export default async function LocaleLayout({ children, params }: LocaleLayoutPro
 
   const language = LANGUAGE_BY_ROUTE_LOCALE[locale];
   const initialMessages = await loadIntlMessages(language);
-  const initialL10n = loadL10nRecord(language);
+  const initialL10nSeed = loadL10nSeed(language);
   const htmlLang = HTML_LANG_BY_LANGUAGE[language] ?? "ko";
   const structuredData = await buildWebsiteStructuredData(language, locale);
   const currentPatch = getStatsPatchVersions()[0] ?? "";
@@ -61,7 +61,7 @@ export default async function LocaleLayout({ children, params }: LocaleLayoutPro
       </head>
       <body>
         <L10nProvider
-          initialL10n={initialL10n}
+          initialL10nSeed={initialL10nSeed}
           initialMessages={initialMessages}
           initialLanguage={language}
         >

--- a/frontend/src/components/L10nProvider.tsx
+++ b/frontend/src/components/L10nProvider.tsx
@@ -57,22 +57,22 @@ export function useL10n() {
 }
 
 interface L10nProviderProps {
-  initialL10n?: Record<string, string>;
+  initialL10nSeed?: Record<string, string>;
   initialMessages: IntlMessages;
   initialLanguage?: SupportedLanguage;
   children: React.ReactNode;
 }
 
 export function L10nProvider({
-  initialL10n,
+  initialL10nSeed,
   initialMessages,
   initialLanguage,
   children,
 }: L10nProviderProps) {
   const serverLanguage = initialLanguage ?? DEFAULT_LANGUAGE;
   const initialL10nMap = React.useMemo(
-    () => (initialL10n ? new Map(Object.entries(initialL10n)) : null),
-    [initialL10n]
+    () => (initialL10nSeed ? new Map(Object.entries(initialL10nSeed)) : null),
+    [initialL10nSeed]
   );
   const [language, setLanguageState] = useState<SupportedLanguage>(serverLanguage);
   const [messages, setMessages] = useState<IntlMessages>(initialMessages);
@@ -88,6 +88,9 @@ export function L10nProvider({
   const l10nCacheRef = useRef<Partial<Record<SupportedLanguage, Map<string, string>>>>(
     initialL10nMap ? { [serverLanguage]: initialL10nMap } : {}
   );
+  const seedLanguagesRef = useRef<Set<SupportedLanguage>>(
+    initialL10nMap ? new Set([serverLanguage]) : new Set()
+  );
 
   useEffect(() => {
     document.documentElement.lang = HTML_LANG_BY_LANGUAGE[language] ?? "ko";
@@ -99,6 +102,7 @@ export function L10nProvider({
 
     const cachedMessages = messageCacheRef.current[language];
     const cachedL10n = l10nCacheRef.current[language];
+    const needsFullL10n = seedLanguagesRef.current.has(language);
 
     if (cachedMessages) {
       setMessages(cachedMessages);
@@ -110,19 +114,20 @@ export function L10nProvider({
       l10nDispatch({ type: "FETCH_START" });
     }
 
-    if (cachedMessages && cachedL10n) {
+    if (cachedMessages && cachedL10n && !needsFullL10n) {
       return;
     }
 
     Promise.all([
       cachedMessages ? Promise.resolve(cachedMessages) : loadIntlMessages(language),
-      cachedL10n ? Promise.resolve(cachedL10n) : fetchAndParseL10n(language),
+      cachedL10n && !needsFullL10n ? Promise.resolve(cachedL10n) : fetchAndParseL10n(language),
     ])
       .then(([nextMessages, nextL10n]) => {
         if (ignore) return;
 
         messageCacheRef.current[language] = nextMessages;
         l10nCacheRef.current[language] = nextL10n;
+        seedLanguagesRef.current.delete(language);
         setMessages(nextMessages);
         l10nDispatch({ type: "FETCH_SUCCESS", payload: nextL10n });
       })

--- a/frontend/src/hooks/useTraitNames.ts
+++ b/frontend/src/hooks/useTraitNames.ts
@@ -8,8 +8,8 @@ const TRAIT_PREFIX = "Trait/Name/";
  * l10n Map에서 `Trait/Name/{code}` 항목만 추출해 `{ code: name }` 매핑 반환.
  * 언어 변경 시(useL10n의 l10n reference 변경) 재계산.
  *
- * 기존엔 `/api/traits/names` 별도 fetch + useState로 관리했으나,
- * L10nProvider가 이미 전체 l10n을 메모리에 들고 있으므로 직접 추출이 빠르고 단순.
+ * L10nProvider가 첫 paint용 seed와 이후 전체 l10n을 같은 Map 형태로 제공하므로
+ * 별도 API 요청 없이 직접 추출한다.
  */
 export function useTraitNames(l10n: Map<string, string>): Record<number, string> {
   return useMemo(() => {

--- a/frontend/src/lib/serverL10n.ts
+++ b/frontend/src/lib/serverL10n.ts
@@ -2,6 +2,9 @@ import { readFileSync } from "fs";
 import { join } from "path";
 import { DEFAULT_LANGUAGE, type SupportedLanguage } from "@/lib/detectLanguage";
 
+const L10N_SEED_PREFIXES = ["Character/Name/", "WeaponType/", "Trait/Name/"] as const;
+const l10nSeedCache = new Map<SupportedLanguage, Record<string, string>>();
+
 export function loadL10nRecord(language: SupportedLanguage): Record<string, string> | undefined {
   try {
     const filePath = join(process.cwd(), `public/l10n/${language}.json`);
@@ -22,4 +25,28 @@ export function loadL10nRecord(language: SupportedLanguage): Record<string, stri
 
 export function loadL10nMap(language: SupportedLanguage): Map<string, string> {
   return new Map(Object.entries(loadL10nRecord(language) ?? {}));
+}
+
+export function extractL10nSeed(l10n: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(l10n).filter(([key]) =>
+      L10N_SEED_PREFIXES.some((prefix) => key.startsWith(prefix))
+    )
+  );
+}
+
+/**
+ * 첫 paint에 필요한 이름만 반환한다. 전체 사전은 client에서 정적 JSON으로 보충한다.
+ * 빌드/ISR 중 동일 언어의 3~4MB 원본을 반복 파싱하지 않도록 seed만 캐시한다.
+ */
+export function loadL10nSeed(language: SupportedLanguage): Record<string, string> | undefined {
+  const cached = l10nSeedCache.get(language);
+  if (cached) return cached;
+
+  const l10n = loadL10nRecord(language);
+  if (!l10n) return undefined;
+
+  const seed = extractL10nSeed(l10n);
+  l10nSeedCache.set(language, seed);
+  return seed;
 }

--- a/frontend/src/lib/serverL10n.ts
+++ b/frontend/src/lib/serverL10n.ts
@@ -28,11 +28,15 @@ export function loadL10nMap(language: SupportedLanguage): Map<string, string> {
 }
 
 export function extractL10nSeed(l10n: Record<string, string>): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(l10n).filter(([key]) =>
-      L10N_SEED_PREFIXES.some((prefix) => key.startsWith(prefix))
-    )
-  );
+  const seed: Record<string, string> = {};
+
+  for (const key of Object.keys(l10n)) {
+    if (L10N_SEED_PREFIXES.some((prefix) => key.startsWith(prefix))) {
+      seed[key] = l10n[key];
+    }
+  }
+
+  return seed;
 }
 
 /**

--- a/frontend/src/utils/l10n.ts
+++ b/frontend/src/utils/l10n.ts
@@ -1,17 +1,12 @@
 // l10n 데이터를 정적 파일에서 가져와서 Map으로 변환
 // public/l10n/{language}.json 은 npm run fetch-l10n 으로 생성
-export async function fetchAndParseL10n(language: string = 'Korean'): Promise<Map<string, string>> {
-  try {
-    const response = await fetch(`/l10n/${language}.json`);
-    if (!response.ok) {
-      throw new Error('l10n 데이터를 불러올 수 없습니다.');
-    }
-    const data = await response.json() as Record<string, string>;
-    return new Map(Object.entries(data));
-  } catch (error) {
-    console.error('l10n 데이터 로딩 실패:', error);
-    return new Map();
+export async function fetchAndParseL10n(language: string = "Korean"): Promise<Map<string, string>> {
+  const response = await fetch(`/l10n/${language}.json`);
+  if (!response.ok) {
+    throw new Error("l10n 데이터를 불러올 수 없습니다.");
   }
+  const data = (await response.json()) as Record<string, string>;
+  return new Map(Object.entries(data));
 }
 
 // 아이템 이름 가져오기
@@ -37,12 +32,12 @@ export function getSkillName(l10n: Map<string, string>, code: number): string | 
 // 전술 스킬 이름 가져오기
 export function getTacticalSkillName(l10n: Map<string, string>, code: number): string | null {
   return l10n.get(`TacticalSkill/Name/${code}`) ?? null;
-} 
+}
 
 // 무기 이름 가져오기
 export function getWeaponName(l10n: Map<string, string>, code: number): string | null {
   return l10n.get(`WeaponType/${code}`) ?? null;
-} 
+}
 
 // 특성(룬) 이름 가져오기
 export function getTraitName(l10n: Map<string, string>, code: number): string | null {


### PR DESCRIPTION
## 변경 사항
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.


## 테스트 결과 (테스트를 했으면)
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.