### PR TITLE
[refactor] 트리오 무기 버킷 조회를 사전 집계 테이블로 전환

### DIFF
--- a/backend/migrations/030_trio_weapon_member_bucket_table.sql
+++ b/backend/migrations/030_trio_weapon_member_bucket_table.sql
@@ -1,0 +1,274 @@
+-- ============================================================
+-- pre-aggregated trio-weapon member bucket table
+--
+-- 목적:
+--   - 요청마다 get_trio_weapon_member_bucket RPC가 수천 개 row를 JSONB_AGG
+--     하면서 PostgREST statement timeout을 넘기는 문제를 제거한다.
+--   - character+weapon별 compact tuple을 패치 집계 시점에 한 번 생성하고,
+--     API 요청에서는 PK로 한 행만 읽는다.
+--
+-- tuple contract:
+--   [
+--     character1, weapon1,
+--     character2, weapon2,
+--     character3, weapon3,
+--     total_games, total_wins, total_rp, rank_sum
+--   ]
+--
+-- 갱신 시점:
+--   - v2_CharacterTrioWeaponPairLookup_agg_next 백필/교체가 끝난 뒤
+--     refresh_trio_weapon_member_buckets()를 호출한다.
+--   - 함수는 새 버킷을 임시 테이블에 완성한 뒤 현재 테이블에 반영한다.
+--     전체 호출이 한 트랜잭션이므로 독자는 commit 전에는 이전 버킷을,
+--     commit 후에는 새 버킷을 보며 중간 상태를 보지 않는다.
+-- ============================================================
+
+BEGIN;
+
+SET LOCAL statement_timeout = '10min';
+
+CREATE TABLE IF NOT EXISTS public."v2_CharacterTrioWeaponMemberBucket" (
+  character_code  INTEGER NOT NULL,
+  weapon_code     INTEGER NOT NULL,
+  item_count      INTEGER NOT NULL,
+  items           JSONB NOT NULL,
+  refreshed_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  PRIMARY KEY (character_code, weapon_code),
+
+  CONSTRAINT v2_trio_weapon_member_bucket_character_positive
+    CHECK (character_code > 0),
+  CONSTRAINT v2_trio_weapon_member_bucket_weapon_positive
+    CHECK (weapon_code > 0),
+  CONSTRAINT v2_trio_weapon_member_bucket_items_array
+    CHECK (JSONB_TYPEOF(items) = 'array'),
+  CONSTRAINT v2_trio_weapon_member_bucket_count_matches
+    CHECK (item_count = JSONB_ARRAY_LENGTH(items))
+);
+
+ALTER TABLE public."v2_CharacterTrioWeaponMemberBucket"
+ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Allow public read trio weapon member bucket"
+ON public."v2_CharacterTrioWeaponMemberBucket";
+
+CREATE POLICY "Allow public read trio weapon member bucket"
+ON public."v2_CharacterTrioWeaponMemberBucket"
+FOR SELECT
+TO anon, authenticated
+USING (true);
+
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
+ON public."v2_CharacterTrioWeaponMemberBucket"
+FROM anon, authenticated;
+
+GRANT SELECT
+ON public."v2_CharacterTrioWeaponMemberBucket"
+TO anon, authenticated, service_role;
+
+
+-- ============================================================
+-- 전체 버킷 원자적 재생성
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.refresh_trio_weapon_member_buckets()
+RETURNS TABLE (
+  bucket_count INTEGER,
+  tuple_count BIGINT,
+  refreshed_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+SET statement_timeout = '10min'
+AS $$
+DECLARE
+  v_refreshed_at TIMESTAMPTZ := CLOCK_TIMESTAMP();
+BEGIN
+  IF TO_REGCLASS('public."v2_CharacterTrioWeaponPairLookup_agg_next"') IS NULL THEN
+    RAISE EXCEPTION
+      'source table public.v2_CharacterTrioWeaponPairLookup_agg_next does not exist';
+  END IF;
+
+  DROP TABLE IF EXISTS pg_temp.trio_weapon_member_bucket_refresh;
+
+  CREATE TEMP TABLE trio_weapon_member_bucket_refresh
+  ON COMMIT DROP
+  AS
+  WITH canonical_trios AS (
+    SELECT
+      source.ally1_char,
+      source.ally1_weapon,
+      source.ally2_char,
+      source.ally2_weapon,
+      source.third_char,
+      source.third_weapon,
+      source.total_games,
+      source.total_wins,
+      source.total_rp,
+      source.rank_sum
+    FROM public."v2_CharacterTrioWeaponPairLookup_agg_next" AS source
+    WHERE
+      -- pair lookup은 trio당 3행이므로 ally1+ally2 pair만 대표로 사용한다.
+      source.pair_key = source.ally1_char::TEXT || ':' || source.ally2_char::TEXT
+      AND source.ally1_char NOT IN (9998, 9999)
+      AND source.ally2_char NOT IN (9998, 9999)
+      AND source.third_char NOT IN (9998, 9999)
+      AND source.ally1_weapon > 0
+      AND source.ally2_weapon > 0
+      AND source.third_weapon > 0
+  ),
+  member_trios AS (
+    SELECT
+      member.character_code,
+      member.weapon_code,
+      trio.ally1_char,
+      trio.ally1_weapon,
+      trio.ally2_char,
+      trio.ally2_weapon,
+      trio.third_char,
+      trio.third_weapon,
+      trio.total_games,
+      trio.total_wins,
+      trio.total_rp,
+      trio.rank_sum
+    FROM canonical_trios AS trio
+    CROSS JOIN LATERAL (
+      VALUES
+        (trio.ally1_char, trio.ally1_weapon),
+        (trio.ally2_char, trio.ally2_weapon),
+        (trio.third_char, trio.third_weapon)
+    ) AS member(character_code, weapon_code)
+  )
+  SELECT
+    member_trios.character_code,
+    member_trios.weapon_code,
+    COUNT(*)::INTEGER AS item_count,
+    JSONB_AGG(
+      JSONB_BUILD_ARRAY(
+        member_trios.ally1_char,
+        member_trios.ally1_weapon,
+        member_trios.ally2_char,
+        member_trios.ally2_weapon,
+        member_trios.third_char,
+        member_trios.third_weapon,
+        member_trios.total_games,
+        member_trios.total_wins,
+        member_trios.total_rp,
+        member_trios.rank_sum
+      )
+      ORDER BY
+        member_trios.total_games DESC,
+        member_trios.ally1_char,
+        member_trios.ally2_char,
+        member_trios.third_char,
+        member_trios.ally1_weapon,
+        member_trios.ally2_weapon,
+        member_trios.third_weapon
+    ) AS items
+  FROM member_trios
+  GROUP BY
+    member_trios.character_code,
+    member_trios.weapon_code;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_temp.trio_weapon_member_bucket_refresh
+  ) THEN
+    RAISE EXCEPTION
+      'refusing to replace trio weapon member buckets with an empty result';
+  END IF;
+
+  INSERT INTO public."v2_CharacterTrioWeaponMemberBucket" (
+    character_code,
+    weapon_code,
+    item_count,
+    items,
+    refreshed_at
+  )
+  SELECT
+    staged.character_code,
+    staged.weapon_code,
+    staged.item_count,
+    staged.items,
+    v_refreshed_at
+  FROM pg_temp.trio_weapon_member_bucket_refresh AS staged
+  ON CONFLICT (character_code, weapon_code)
+  DO UPDATE SET
+    item_count = EXCLUDED.item_count,
+    items = EXCLUDED.items,
+    refreshed_at = EXCLUDED.refreshed_at;
+
+  DELETE FROM public."v2_CharacterTrioWeaponMemberBucket" AS current
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM pg_temp.trio_weapon_member_bucket_refresh AS staged
+    WHERE staged.character_code = current.character_code
+      AND staged.weapon_code = current.weapon_code
+  );
+
+  RETURN QUERY
+  SELECT
+    COUNT(*)::INTEGER AS bucket_count,
+    COALESCE(SUM(staged.item_count), 0)::BIGINT AS tuple_count,
+    v_refreshed_at AS refreshed_at
+  FROM pg_temp.trio_weapon_member_bucket_refresh AS staged;
+END;
+$$;
+
+COMMENT ON TABLE public."v2_CharacterTrioWeaponMemberBucket"
+IS 'Pre-aggregated compact trio tuples keyed by character+weapon for request-time single-row lookup.';
+
+COMMENT ON FUNCTION public.refresh_trio_weapon_member_buckets()
+IS 'Atomically rebuilds character+weapon tuple buckets from canonical rows in v2_CharacterTrioWeaponPairLookup_agg_next.';
+
+REVOKE ALL
+ON FUNCTION public.refresh_trio_weapon_member_buckets()
+FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE
+ON FUNCTION public.refresh_trio_weapon_member_buckets()
+TO service_role;
+
+
+-- 기존 source로 최초 버킷을 채운다. 빈 결과면 함수가 예외를 발생시켜
+-- 테이블/API 전환이 불완전한 상태로 commit되는 것을 막는다.
+SELECT *
+FROM public.refresh_trio_weapon_member_buckets();
+
+ANALYZE public."v2_CharacterTrioWeaponMemberBucket";
+
+COMMIT;
+
+-- 새 table/function을 PostgREST가 즉시 인식하도록 schema cache를 갱신한다.
+NOTIFY pgrst, 'reload schema';
+
+
+-- ============================================================
+-- 배포 전 검증
+-- ============================================================
+
+-- 1) 버킷 수, tuple 수, 갱신 시각
+-- SELECT
+--   COUNT(*) AS bucket_count,
+--   SUM(item_count) AS tuple_count,
+--   MIN(refreshed_at) AS oldest_bucket,
+--   MAX(refreshed_at) AS newest_bucket
+-- FROM public."v2_CharacterTrioWeaponMemberBucket";
+
+-- 2) 대표 버킷 크기
+-- SELECT
+--   character_code,
+--   weapon_code,
+--   item_count,
+--   ROUND(OCTET_LENGTH(items::TEXT) / 1024.0 / 1024.0, 3) AS items_mib
+-- FROM public."v2_CharacterTrioWeaponMemberBucket"
+-- ORDER BY item_count DESC
+-- LIMIT 10;
+
+-- 3) 패치 집계 테이블 교체 후 재생성
+-- SELECT * FROM public.refresh_trio_weapon_member_buckets();
+
+-- 롤백:
+-- DROP FUNCTION IF EXISTS public.refresh_trio_weapon_member_buckets();
+-- DROP TABLE IF EXISTS public."v2_CharacterTrioWeaponMemberBucket";

--- a/frontend/src/__tests__/trioWeaponRoute.test.ts
+++ b/frontend/src/__tests__/trioWeaponRoute.test.ts
@@ -1,0 +1,89 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GET } from "@/app/api/stats/trios-weapon/route";
+
+const mocks = vi.hoisted(() => ({
+  from: vi.fn(),
+  rpc: vi.fn(),
+  tryNestApiProxy: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  unstable_cache:
+    <T>(loader: () => Promise<T>) =>
+    () =>
+      loader(),
+}));
+
+vi.mock("@/lib/server/nestProxy", () => ({
+  tryNestApiProxy: mocks.tryNestApiProxy,
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  createServerClient: () => ({
+    from: mocks.from,
+    rpc: mocks.rpc,
+  }),
+}));
+
+const BUCKET_TUPLE = [6, 8, 10, 1, 22, 3, 120, 30, 3240, 420];
+
+function mockBucketQuery(data: unknown) {
+  const query = {
+    select: vi.fn(),
+    eq: vi.fn(),
+    maybeSingle: vi.fn().mockResolvedValue({ data, error: null }),
+  };
+  query.select.mockReturnValue(query);
+  query.eq.mockReturnValue(query);
+  mocks.from.mockReturnValue(query);
+  return query;
+}
+
+describe("GET /api/stats/trios-weapon tuple bucket", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.tryNestApiProxy.mockResolvedValue(null);
+  });
+
+  it("요청 시 RPC 집계 대신 character+weapon 버킷 한 행을 조회한다", async () => {
+    const query = mockBucketQuery({
+      item_count: 1,
+      items: [BUCKET_TUPLE],
+    });
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/stats/trios-weapon?character1=6&weapon1=8&format=tuple")
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      version: 1,
+      itemCount: 1,
+      items: [BUCKET_TUPLE],
+    });
+    expect(mocks.from).toHaveBeenCalledWith("v2_CharacterTrioWeaponMemberBucket");
+    expect(query.select).toHaveBeenCalledWith("item_count,items");
+    expect(query.eq).toHaveBeenNthCalledWith(1, "character_code", 6);
+    expect(query.eq).toHaveBeenNthCalledWith(2, "weapon_code", 8);
+    expect(query.maybeSingle).toHaveBeenCalledOnce();
+    expect(mocks.rpc).not.toHaveBeenCalled();
+  });
+
+  it("존재하지 않는 character+weapon은 빈 tuple 버킷으로 반환한다", async () => {
+    mockBucketQuery(null);
+
+    const response = await GET(
+      new NextRequest(
+        "http://localhost/api/stats/trios-weapon?character1=999&weapon1=999&format=tuple"
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      version: 1,
+      itemCount: 0,
+      items: [],
+    });
+  });
+});

--- a/frontend/src/__tests__/trioWeaponTuple.test.ts
+++ b/frontend/src/__tests__/trioWeaponTuple.test.ts
@@ -11,7 +11,7 @@ const FIRST_TUPLE: CachedTrioWeaponTuple = [6, 8, 10, 1, 22, 3, 120, 30, 3240, 4
 const SECOND_TUPLE: CachedTrioWeaponTuple = [6, 8, 11, 2, 23, 4, 80, 16, 1680, 320];
 
 describe("trioWeaponTuple", () => {
-  it("RPC JSON tuple을 검증하고 숫자로 정규화한다", () => {
+  it("bucket JSON tuple을 검증하고 숫자로 정규화한다", () => {
     expect(parseTrioWeaponTuple(["6", 8, 10, 1, 22, 3, 120, 30, 3240, 420])).toEqual(FIRST_TUPLE);
     expect(() => parseTrioWeaponTuple([6, 8])).toThrow("invalid_trio_weapon_member_bucket_tuple");
     expect(() => parseTrioWeaponTuple([6, 8, 10, 1, 22, 3, 120, 30, "not-a-number", 420])).toThrow(

--- a/frontend/src/app/api/internal/revalidate/route.ts
+++ b/frontend/src/app/api/internal/revalidate/route.ts
@@ -17,6 +17,7 @@ export const dynamic = "force-dynamic";
  *   - v2_CharacterTrioWeapon                → "trios-weapon"
  *   - v2_CharacterTrioWeaponSearch_all      → "trios-weapon"
  *   - v2_CharacterTrioWeaponPairLookup_*    → "trios-weapon"
+ *   - v2_CharacterTrioWeaponMemberBucket    → "trios-weapon"
  *   - v2_CharacterStats / CharacterStats    → "character-stats:rows" + "character-stats:patch:<patchVersion>" 등 (lib/characterStats.ts 참조)
  *   - chars 배열의 각 코드               → "trios:char:<n>", "trios-weapon:char:<n>"
  */
@@ -28,6 +29,7 @@ const TABLE_TAG_MAP: Record<string, string[]> = {
   v2_CharacterTrioWeaponSearch_all: ["trios-weapon"],
   v2_CharacterTrioWeaponPairLookup_agg_next: ["trios-weapon"],
   v2_CharacterTrioWeaponPairLookup_all_next: ["trios-weapon"],
+  v2_CharacterTrioWeaponMemberBucket: ["trios-weapon"],
   v2_CharacterStats: ["character-stats:rows"],
   CharacterStats: ["character-stats:rows"],
 };

--- a/frontend/src/app/api/stats/trios-weapon/route.ts
+++ b/frontend/src/app/api/stats/trios-weapon/route.ts
@@ -11,7 +11,7 @@ import {
 
 const EXCLUDED_CHARACTER_CODES = new Set([9998, 9999]);
 const TRIO_WEAPON_SEARCH_TABLE = "v2_CharacterTrioWeaponSearch_all";
-const TRIO_WEAPON_MEMBER_BUCKET_RPC = "get_trio_weapon_member_bucket";
+const TRIO_WEAPON_MEMBER_BUCKET_TABLE = "v2_CharacterTrioWeaponMemberBucket";
 const TRIO_WEAPON_PAIR_LOOKUP_TABLES = [
   "v2_CharacterTrioWeaponPairLookup_agg_next",
   "v2_CharacterTrioWeaponPairLookup_all_next",
@@ -24,7 +24,7 @@ const DB_PAGE_SIZE = 1000;
 const PARALLEL_FETCH_LIMIT = 5000;
 const FULL_FETCH_LIMIT = 5000;
 const MAX_RESPONSE_LIMIT = FULL_FETCH_LIMIT;
-const TRIO_WEAPON_CACHE_VERSION = "v14";
+const TRIO_WEAPON_CACHE_VERSION = "v15";
 
 // L1 캐시 TTL — source 가 사전 집계 테이블(v2_CharacterTrioWeapon* / search_all)이고
 // tag-based invalidation 으로 즉시 갱신되므로 7d. member+weapon 버킷을 오래 유지해
@@ -98,7 +98,7 @@ interface AggregatedTrioWeapon {
   averageRank: number;
 }
 
-interface MemberWeaponBucketRpcRow {
+interface MemberWeaponBucketRow {
   item_count: number;
   items: unknown;
 }
@@ -374,8 +374,8 @@ async function fetchTrioWeaponPair(char1: number, char2: number): Promise<Aggreg
 }
 
 /**
- * character+weapon 한 개를 anchor로 compact tuple bucket을 가져온다.
- * RPC가 canonical pair row만 읽으므로 pair lookup의 3배 중복은 응답에 포함되지 않는다.
+ * character+weapon 한 개를 anchor로 사전 집계된 compact tuple bucket 한 행을 가져온다.
+ * 패치 집계 시 canonical pair row에서 미리 생성하므로 요청 경로에서는 JSONB_AGG를 하지 않는다.
  */
 async function fetchTrioWeaponMemberWeaponBucket(
   character: number,
@@ -383,16 +383,17 @@ async function fetchTrioWeaponMemberWeaponBucket(
 ): Promise<CachedTrioWeaponTuple[]> {
   const supabase = createServerClient();
   const { data, error } = await supabase
-    .rpc(TRIO_WEAPON_MEMBER_BUCKET_RPC, {
-      p_character: character,
-      p_weapon: weapon,
-    })
-    .single();
+    .from(TRIO_WEAPON_MEMBER_BUCKET_TABLE)
+    .select("item_count,items")
+    .eq("character_code", character)
+    .eq("weapon_code", weapon)
+    .maybeSingle();
 
   if (error) throw error;
+  if (!data) return [];
 
-  const bucket = data as MemberWeaponBucketRpcRow | null;
-  if (!bucket || !Array.isArray(bucket.items)) {
+  const bucket = data as MemberWeaponBucketRow;
+  if (!Array.isArray(bucket.items)) {
     throw new Error("invalid_trio_weapon_member_bucket_response");
   }
 
@@ -539,7 +540,7 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const tupleFormat = searchParams.get("format") === "tuple";
 
-  // compact tuple 계약은 이 Next route와 Supabase RPC가 담당한다.
+  // compact tuple 계약은 이 Next route와 Supabase bucket table이 담당한다.
   // Nest가 아직 같은 계약을 제공하지 않으므로 기존 object 요청만 proxy한다.
   if (!tupleFormat) {
     const proxied = await tryNestApiProxy(request, "/stats/trios-weapon");


### PR DESCRIPTION
## 변경 사항

- Closes #197
- Data Cache MISS마다 수천 개 행을 `JSONB_AGG`하던 RPC가 PostgreSQL `57014` statement timeout을 발생시키던 문제를 해결했습니다.
- 기존 canonical pair 사전 집계에서 `(캐릭터, 무기)`별 compact tuple 버킷을 미리 생성하고, 빈 결과를 거부한 뒤 한 트랜잭션에서 원자적으로 교체하도록 구성했습니다.
- trio-weapon API는 요청 시점 RPC 대신 PK 기반 버킷 단일 행을 조회하며, 캐시 버전을 `v15`로 분리하고 무효화 태그를 연결했습니다.
- route 단위 테스트에서 버킷 테이블 조회, 빈 버킷 응답, RPC 미호출을 검증했습니다.

> 배포 시 `030_trio_weapon_member_bucket_table.sql`을 먼저 적용한 뒤 프론트를 배포해야 합니다.

## 테스트 결과 (테스트를 했으면)

- `npm test`: 19 files, 165 tests passed
- `npx eslint`: 대상 API·테스트 파일 통과
- `npx tsc --noEmit`: 통과
- `npm run test:e2e -- e2e/flows/synergy-request-race.spec.ts --project=chromium-desktop`: 1 passed
- 로컬 실사용 확인: Data Cache MISS 약 885ms, HIT 약 17ms, 기준 버킷 재사용 및 브라우저 필터링 정상
