### PR TITLE
feat: 12.2 패치노트 및 통계 전환 반영

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -195,7 +195,7 @@
     },
     "preseasonNotice": "Patch 11.0 uses preseason data and is not provided.",
     "preseasonPolicyNotice": "Preseason matches are not included in our statistics.",
-    "collectionPolicyNotice": "Eternal Return ranked play opened at 7:15 PM KST, so data collection is taking some time.",
+    "collectionPolicyNotice": "New patch statistics are published after 50,000 Diamond+ ranked games are collected.",
     "collecting": {
       "subtitle": "Ranked data for patch {patch} is being collected for meta analysis.",
       "kicker": "Collecting patch {patch}",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -149,7 +149,7 @@
     },
     "preseasonNotice": "11.0はプレシーズンデータのため提供していません。",
     "preseasonPolicyNotice": "プレシーズン期間の統計は集計していません。",
-    "collectionPolicyNotice": "エターナルリターンのランクが午後7時15分（KST）に解放されたため、データ集計に時間がかかっています。",
+    "collectionPolicyNotice": "新パッチの統計は、ダイヤモンド以上のランク戦を50,000ゲーム集計した後に公開します。",
     "collecting": {
       "subtitle": "パッチ{patch}のメタ分析に向けてランクデータを集計しています。",
       "kicker": "パッチ{patch}集計中",

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -189,7 +189,7 @@
     },
     "preseasonNotice": "11.0 버전은 프리시즌 데이터이므로 제공하지 않습니다.",
     "preseasonPolicyNotice": "프리시즌 기간에는 통계를 집계하지 않습니다.",
-    "collectionPolicyNotice": "이터널리턴 랭크가 오후 7시 15분에 열려 데이터 집계에 시간이 걸리고 있습니다.",
+    "collectionPolicyNotice": "새 패치 통계는 다이아 이상 랭크 표본 50,000게임을 확보한 뒤 공개합니다.",
     "collecting": {
       "subtitle": "패치 {patch} 메타 분석을 위한 랭크 데이터를 집계하고 있습니다.",
       "kicker": "패치 {patch} 집계 중",

--- a/frontend/messages/zh-Hans.json
+++ b/frontend/messages/zh-Hans.json
@@ -148,7 +148,7 @@
     },
     "preseasonNotice": "11.0 为季前赛数据，因此不提供。",
     "preseasonPolicyNotice": "季前赛期间的数据不纳入统计。",
-    "collectionPolicyNotice": "永恒轮回排位模式于韩国时间晚上7点15分开放，因此数据收集需要一些时间。",
+    "collectionPolicyNotice": "新版本统计将在收集到50,000场钻石及以上排位赛后发布。",
     "collecting": {
       "subtitle": "正在收集12.1版本的排位数据用于版本分析。",
       "kicker": "正在收集{patch}版本",

--- a/frontend/messages/zh-Hant.json
+++ b/frontend/messages/zh-Hant.json
@@ -148,7 +148,7 @@
     },
     "preseasonNotice": "11.0 為季前賽資料，因此不提供。",
     "preseasonPolicyNotice": "季前賽期間的資料不納入統計。",
-    "collectionPolicyNotice": "永恆輪迴牌位模式於韓國時間晚上7點15分開放，因此資料收集需要一些時間。",
+    "collectionPolicyNotice": "新版本統計將在收集到50,000場鑽石及以上牌位賽後發布。",
     "collecting": {
       "subtitle": "正在收集12.1版本的牌位資料用於版本分析。",
       "kicker": "正在收集{patch}版本",

--- a/frontend/src/__tests__/homeMetaShared.test.ts
+++ b/frontend/src/__tests__/homeMetaShared.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { buildHomeMetaView, type HomeMetaStats } from "@/lib/homeMetaShared";
+import {
+  buildHomeMetaView,
+  filterReadyStatsPatchVersions,
+  HOME_META_MIN_COLLECTED_GAMES,
+  type HomeMetaStats,
+} from "@/lib/homeMetaShared";
 
 const stats: HomeMetaStats = {
   patchVersion: "12.1",
@@ -49,5 +54,20 @@ describe("buildHomeMetaView cumulative tiers", () => {
   ])("%s 누적 범위를 적용한다", (tier, expectedGames) => {
     const view = buildHomeMetaView(stats, tier);
     expect(view.rankingData.rankings[0]?.totalGames).toBe(expectedGames);
+  });
+});
+
+describe("latest stats patch sample gate", () => {
+  const patches = ["12.2", "12.1", "11.7"];
+
+  it("기준 판수 전에는 12.1을 최신 통계 패치로 유지한다", () => {
+    expect(filterReadyStatsPatchVersions(patches, HOME_META_MIN_COLLECTED_GAMES - 1)).toEqual([
+      "12.1",
+      "11.7",
+    ]);
+  });
+
+  it("기준 판수를 채우면 12.2를 최신 통계 패치로 공개한다", () => {
+    expect(filterReadyStatsPatchVersions(patches, HOME_META_MIN_COLLECTED_GAMES)).toEqual(patches);
   });
 });

--- a/frontend/src/__tests__/patchNotes.test.ts
+++ b/frontend/src/__tests__/patchNotes.test.ts
@@ -46,7 +46,7 @@ describe("12.0 patch notes", () => {
 
   it("프리시즌 12.0을 통계 패치 목록에서는 제외한다", () => {
     expect(getStatsPatchVersions()).not.toContain("12.0");
-    expect(getStatsPatchVersions()[0]).toBe("12.1");
+    expect(getStatsPatchVersions()).toContain("12.1");
   });
 
   it("공식 실험체 변경 수와 유형을 보존한다", () => {
@@ -69,9 +69,9 @@ describe("12.0 patch notes", () => {
 });
 
 describe("12.1 patch notes", () => {
-  it("12.1을 최신 패치 및 통계 패치로 노출한다", () => {
-    expect(getAllPatchVersions()[0]).toBe("12.1");
-    expect(getStatsPatchVersions()[0]).toBe("12.1");
+  it("12.1을 패치 및 통계 이력에 보존한다", () => {
+    expect(getAllPatchVersions()).toContain("12.1");
+    expect(getStatsPatchVersions()).toContain("12.1");
   });
 
   it("공식 실험체 변경 수와 유형을 보존한다", () => {
@@ -97,5 +97,32 @@ describe("12.1 patch notes", () => {
     const elena = getCharacterPatchNote(50, "12.1");
 
     expect(elena?.changes.map((change) => change.changeType)).toEqual(["buff", "nerf"]);
+  });
+});
+
+describe("12.2 patch notes", () => {
+  it("12.2를 최신 패치 및 통계 후보로 노출한다", () => {
+    expect(getAllPatchVersions()[0]).toBe("12.2");
+    expect(getStatsPatchVersions()[0]).toBe("12.2");
+  });
+
+  it("공식 실험체 변경 수와 유형을 보존한다", () => {
+    expect(getNotesByPatch("12.2")).toHaveLength(37);
+    expect(getPatchSummary("12.2")).toEqual({
+      patch: "12.2",
+      totalChanges: 52,
+      buffs: 32,
+      nerfs: 20,
+      reworks: 0,
+      characterCount: 37,
+    });
+  });
+
+  it("무기별 상향과 하향이 함께 있는 재키 변경을 각각 기록한다", () => {
+    expect(getCharacterPatchNote(1, "12.2")?.changes.map((change) => change.changeType)).toEqual([
+      "nerf",
+      "nerf",
+      "buff",
+    ]);
   });
 });

--- a/frontend/src/app/(default)/character/[code]/page.tsx
+++ b/frontend/src/app/(default)/character/[code]/page.tsx
@@ -2,11 +2,11 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { CharacterPageContent } from "@/components/features/character-analysis/CharacterPageContent";
 import { CHARACTER_CODES } from "@/components/features/character-analysis/constants";
-import { getVisibleStatsPatchVersions } from "@/data/patch-notes";
 import { buildFallbackMap, resolveCharacterName } from "@/lib/characterMap";
 import { getCachedCharacterStats } from "@/lib/characterStats";
 import { DEFAULT_CHARACTER_ANALYSIS_TIER } from "@/lib/characterTier";
 import { DEFAULT_LANGUAGE } from "@/lib/detectLanguage";
+import { getPatches } from "@/lib/getPatches";
 import { buildDefaultAlternates } from "@/lib/seoLocales";
 import { loadL10nMap } from "@/lib/serverL10n";
 import { BASE_URL } from "@/lib/siteMetadata";
@@ -14,6 +14,7 @@ import { getStaticTranslator, OG_LOCALE_BY_LANGUAGE } from "@/lib/staticIntl";
 
 export const dynamic = "force-static";
 export const dynamicParams = false;
+export const revalidate = 900;
 
 interface Props {
   params: Promise<{ code: string }>;
@@ -28,7 +29,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   const code = parseInt(rawCode, 10);
   const t = await getStaticTranslator("characterMetadata", DEFAULT_LANGUAGE);
-  const currentPatch = getVisibleStatsPatchVersions()[0];
+  const currentPatch = (await getPatches())[0];
   const name =
     !Number.isNaN(code) && CHARACTER_CODES.includes(code)
       ? resolveCharacterName(code, loadL10nMap(DEFAULT_LANGUAGE), buildFallbackMap())
@@ -123,8 +124,8 @@ export default async function DefaultCharacterPage({ params }: Props) {
     notFound();
   }
 
-  // 통계용 패치 목록(제외 패치 제외). 최신 버전이 자동으로 맨 앞(기본 선택)에 온다.
-  const patches = getVisibleStatsPatchVersions();
+  // 최신 패치는 기준 표본을 채운 뒤 자동으로 맨 앞(기본 선택)에 온다.
+  const patches = await getPatches();
   const [currentPatch, previousPatch] = patches;
   const [initialStats, initialPrevStats] = await Promise.all([
     currentPatch

--- a/frontend/src/app/(site)/[locale]/character/[code]/page.tsx
+++ b/frontend/src/app/(site)/[locale]/character/[code]/page.tsx
@@ -3,11 +3,11 @@ import { notFound } from "next/navigation";
 import { setRequestLocale } from "next-intl/server";
 import { CharacterPageContent } from "@/components/features/character-analysis/CharacterPageContent";
 import { CHARACTER_CODES } from "@/components/features/character-analysis/constants";
-import { getVisibleStatsPatchVersions } from "@/data/patch-notes";
 import { LANGUAGE_BY_ROUTE_LOCALE, ROUTE_LOCALES, isRouteLocale } from "@/i18n/routing";
 import { buildFallbackMap, resolveCharacterName } from "@/lib/characterMap";
 import { getCachedCharacterStats } from "@/lib/characterStats";
 import { DEFAULT_CHARACTER_ANALYSIS_TIER } from "@/lib/characterTier";
+import { getPatches } from "@/lib/getPatches";
 import { buildLocalizedAlternates, localizeRoutePath } from "@/lib/seoLocales";
 import { loadL10nMap } from "@/lib/serverL10n";
 import { BASE_URL } from "@/lib/siteMetadata";
@@ -15,6 +15,7 @@ import { getStaticTranslator, OG_LOCALE_BY_LANGUAGE } from "@/lib/staticIntl";
 
 export const dynamic = "force-static";
 export const dynamicParams = false;
+export const revalidate = 900;
 
 interface Props {
   params: Promise<{ locale: string; code: string }>;
@@ -36,7 +37,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   const code = parseInt(rawCode, 10);
   const translatorPromise = getStaticTranslator("characterMetadata", language);
-  const currentPatch = getVisibleStatsPatchVersions()[0];
+  const currentPatch = (await getPatches())[0];
   const name =
     !Number.isNaN(code) && CHARACTER_CODES.includes(code)
       ? resolveCharacterName(code, loadL10nMap(language), buildFallbackMap())
@@ -169,8 +170,8 @@ export default async function LocalizedCharacterPage({ params }: Props) {
     notFound();
   }
 
-  // 통계용 패치 목록(제외 패치 제외). 최신 버전이 자동으로 맨 앞(기본 선택)에 온다.
-  const patches = getVisibleStatsPatchVersions();
+  // 최신 패치는 기준 표본을 채운 뒤 자동으로 맨 앞(기본 선택)에 온다.
+  const patches = await getPatches();
   const [currentPatch, previousPatch] = patches;
   const [initialStats, initialPrevStats] = await Promise.all([
     currentPatch

--- a/frontend/src/app/(site)/[locale]/page.tsx
+++ b/frontend/src/app/(site)/[locale]/page.tsx
@@ -7,7 +7,7 @@ import { getPatches } from "@/lib/getPatches";
 import { getCachedHomeMetaStats } from "@/lib/homeMetaServer";
 import {
   DEFAULT_HOME_TIER,
-  HOME_META_CURRENT_PATCH,
+  HOME_META_FALLBACK_PATCH,
   buildHomeMetaView,
   createEmptyHomeMetaStats,
 } from "@/lib/homeMetaShared";
@@ -15,7 +15,7 @@ import { buildLocalizedAlternates, localizeRoutePath } from "@/lib/seoLocales";
 import { BASE_URL } from "@/lib/siteMetadata";
 import { getMessage, loadIntlMessages, OG_LOCALE_BY_LANGUAGE } from "@/lib/staticIntl";
 
-export const revalidate = 3600;
+export const revalidate = 900;
 export const dynamic = "force-static";
 export const dynamicParams = false;
 
@@ -80,11 +80,8 @@ export default async function LocalizedHomePage({ params }: LocalePageProps) {
   setRequestLocale(locale);
 
   const availablePatches = await getPatches();
-  const patches = [
-    HOME_META_CURRENT_PATCH,
-    ...availablePatches.filter((patch) => patch !== HOME_META_CURRENT_PATCH),
-  ];
-  const currentPatch = HOME_META_CURRENT_PATCH;
+  const currentPatch = availablePatches[0] ?? HOME_META_FALLBACK_PATCH;
+  const patches = [currentPatch, ...availablePatches.filter((patch) => patch !== currentPatch)];
   let homeMetaStats = createEmptyHomeMetaStats(currentPatch);
 
   try {

--- a/frontend/src/app/api/builds/traits/main/route.ts
+++ b/frontend/src/app/api/builds/traits/main/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getStatsPatchVersions } from "@/data/patch-notes";
 import { getCacheHeaders } from "@/lib/cache";
+import { getPatches } from "@/lib/getPatches";
 import { tryNestApiProxy } from "@/lib/server/nestProxy";
 import { createServerClient } from "@/lib/supabase";
 import { expandCumulativeTier } from "@/utils/tier";
@@ -110,7 +110,7 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const characterCode = Number(searchParams.get("characterCode"));
   const tier = searchParams.get("tier") ?? "DIAMOND";
-  const patchVersion = searchParams.get("patchVersion") ?? getStatsPatchVersions()[0];
+  const patchVersion = searchParams.get("patchVersion") ?? (await getPatches())[0];
   const bestWeapon = searchParams.get("bestWeapon");
 
   if (!characterCode || isNaN(characterCode)) {

--- a/frontend/src/app/api/builds/traits/options/route.ts
+++ b/frontend/src/app/api/builds/traits/options/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getStatsPatchVersions } from "@/data/patch-notes";
 import { getCacheHeaders } from "@/lib/cache";
+import { getPatches } from "@/lib/getPatches";
 import { tryNestApiProxy } from "@/lib/server/nestProxy";
 import { createServerClient } from "@/lib/supabase";
 import { expandCumulativeTier } from "@/utils/tier";
@@ -21,7 +21,7 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const characterCode = Number(searchParams.get("characterCode"));
   const tier = searchParams.get("tier") ?? "DIAMOND";
-  const patchVersion = searchParams.get("patchVersion") ?? getStatsPatchVersions()[0];
+  const patchVersion = searchParams.get("patchVersion") ?? (await getPatches())[0];
   const bestWeapon = searchParams.get("bestWeapon");
 
   if (!characterCode || isNaN(characterCode)) {

--- a/frontend/src/app/api/character/insights/[characterCode]/route.ts
+++ b/frontend/src/app/api/character/insights/[characterCode]/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getStatsPatchVersions } from "@/data/patch-notes";
 import { isRouteLocale, LANGUAGE_BY_ROUTE_LOCALE } from "@/i18n/routing";
 import { buildCharacterInsight } from "@/lib/characterInsights";
 import { buildFallbackMap, resolveCharacterName } from "@/lib/characterMap";
 import { getCachedCharacterStats } from "@/lib/characterStats";
 import { DEFAULT_CHARACTER_ANALYSIS_TIER } from "@/lib/characterTier";
+import { getPatches } from "@/lib/getPatches";
 import { tryNestApiProxy } from "@/lib/server/nestProxy";
 import { loadL10nMap } from "@/lib/serverL10n";
 import { resolveWeaponName } from "@/lib/weaponMap";
@@ -25,8 +25,9 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
   }
 
   const searchParams = request.nextUrl.searchParams;
-  const patchVersion = searchParams.get("patchVersion") ?? getStatsPatchVersions()[0] ?? "";
-  const previousPatch = getStatsPatchVersions().find((patch) => patch !== patchVersion) ?? null;
+  const patches = await getPatches();
+  const patchVersion = searchParams.get("patchVersion") ?? patches[0] ?? "";
+  const previousPatch = patches.find((patch) => patch !== patchVersion) ?? null;
   const tier = searchParams.get("tier") ?? DEFAULT_CHARACTER_ANALYSIS_TIER;
   const localeParam = searchParams.get("locale");
   const locale = localeParam && isRouteLocale(localeParam) ? localeParam : "ko";

--- a/frontend/src/app/api/character/stats-history/[characterCode]/route.ts
+++ b/frontend/src/app/api/character/stats-history/[characterCode]/route.ts
@@ -3,6 +3,7 @@ import { getStatsPatchVersions } from "@/data/patch-notes";
 import { getCacheHeaders, SERVER_ERROR_HEADERS, withCacheObservability } from "@/lib/cache";
 import { getCachedCharacterStats, type CharacterStatsResponse } from "@/lib/characterStats";
 import { DEFAULT_CHARACTER_ANALYSIS_TIER } from "@/lib/characterTier";
+import { getPatches } from "@/lib/getPatches";
 
 interface CharacterStatsHistoryResponse {
   characterCode: number;
@@ -11,9 +12,9 @@ interface CharacterStatsHistoryResponse {
   stats: Array<CharacterStatsResponse | null>;
 }
 
-function parseRequestedPatches(raw: string | null): string[] {
+function parseRequestedPatches(raw: string | null, defaultPatches: string[]): string[] {
   const allowed = new Set(getStatsPatchVersions());
-  if (!raw) return getStatsPatchVersions();
+  if (!raw) return defaultPatches;
 
   const requested = Array.from(
     new Set(
@@ -24,7 +25,7 @@ function parseRequestedPatches(raw: string | null): string[] {
     )
   );
 
-  return requested.length > 0 ? requested : getStatsPatchVersions();
+  return requested.length > 0 ? requested : defaultPatches;
 }
 
 export async function GET(
@@ -40,7 +41,7 @@ export async function GET(
 
   const { searchParams } = new URL(request.url);
   const tier = searchParams.get("tier") ?? DEFAULT_CHARACTER_ANALYSIS_TIER;
-  const patches = parseRequestedPatches(searchParams.get("patchVersions"));
+  const patches = parseRequestedPatches(searchParams.get("patchVersions"), await getPatches());
 
   try {
     const t0 = Date.now();

--- a/frontend/src/app/api/character/stats/[characterCode]/route.ts
+++ b/frontend/src/app/api/character/stats/[characterCode]/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getStatsPatchVersions } from "@/data/patch-notes";
 import { getCacheHeaders, SERVER_ERROR_HEADERS, withCacheObservability } from "@/lib/cache";
 import { getCachedCharacterStats, type CharacterStatsResponse } from "@/lib/characterStats";
 import { DEFAULT_CHARACTER_ANALYSIS_TIER } from "@/lib/characterTier";
+import { getPatches } from "@/lib/getPatches";
 import { tryNestApiProxy } from "@/lib/server/nestProxy";
 
 export type { CharacterStatsResponse, WeaponStatItem } from "@/lib/characterStats";
@@ -23,7 +23,7 @@ export async function GET(
 
   const { searchParams } = new URL(request.url);
   const tier = searchParams.get("tier") ?? DEFAULT_CHARACTER_ANALYSIS_TIER;
-  const patchVersion = searchParams.get("patchVersion") ?? getStatsPatchVersions()[0];
+  const patchVersion = searchParams.get("patchVersion") ?? (await getPatches())[0];
 
   try {
     const t0 = Date.now();

--- a/frontend/src/app/api/meta/honey-picks/route.ts
+++ b/frontend/src/app/api/meta/honey-picks/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getStatsPatchVersions } from "@/data/patch-notes";
 import { getCacheHeaders, NO_CACHE_HEADERS } from "@/lib/cache";
+import { getPatches } from "@/lib/getPatches";
 import { getCachedHoneyPicks } from "@/lib/honeyPicks";
 import { tryNestApiProxy } from "@/lib/server/nestProxy";
 
@@ -11,7 +11,7 @@ export async function GET(request: NextRequest) {
   if (proxied) return proxied;
 
   const { searchParams } = new URL(request.url);
-  const patchVersion = searchParams.get("patchVersion") ?? getStatsPatchVersions()[0];
+  const patchVersion = searchParams.get("patchVersion") ?? (await getPatches())[0];
   const requestedTier = searchParams.get("tier") ?? "DIAMOND";
 
   try {

--- a/frontend/src/components/features/home/HomePageContent.tsx
+++ b/frontend/src/components/features/home/HomePageContent.tsx
@@ -12,7 +12,12 @@ import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 import { CharacterSearchCombobox } from "@/components/features/character-analysis/CharacterSearchCombobox";
 import type { HomeMetaStats } from "@/lib/homeMetaShared";
-import { HOME_META_CURRENT_PATCH, HOME_META_MIN_COLLECTED_GAMES } from "@/lib/homeMetaShared";
+import {
+  HOME_META_FALLBACK_PATCH,
+  HOME_META_MIN_COLLECTED_GAMES,
+  HOME_META_TARGET_PATCH,
+  isHomeMetaTargetReady,
+} from "@/lib/homeMetaShared";
 import type { RankingResponse } from "@/lib/ranking";
 import { HomeDashboardSections } from "./HomeDashboardSections";
 
@@ -44,8 +49,7 @@ export async function HomePageContent({
   const collectedGames = homeMetaStats.collectedGames ?? 0;
   const hasRankingData = rankingData.rankings.length > 0 && rankingGames > 0;
   const isCollectionReady =
-    homeMetaStats.patchVersion === HOME_META_CURRENT_PATCH &&
-    collectedGames >= HOME_META_MIN_COLLECTED_GAMES;
+    homeMetaStats.patchVersion !== HOME_META_TARGET_PATCH || isHomeMetaTargetReady(collectedGames);
   const collectionProgress = Math.min(
     100,
     Math.floor((collectedGames / HOME_META_MIN_COLLECTED_GAMES) * 100)
@@ -53,7 +57,7 @@ export async function HomePageContent({
   const trackedMatches = isCollectionReady
     ? formatMetricNumber(collectedGames / ESTIMATED_PARTICIPANTS_PER_MATCH)
     : "";
-  const fallbackPatch = currentPatch || defaultPatch || "12.1";
+  const fallbackPatch = currentPatch || defaultPatch || HOME_META_FALLBACK_PATCH;
   const patchAnalysisHref = `/${locale}/patch-analysis/11.5`;
   const isPreseasonPreparing = currentPatch === "12.0";
   const isCollectionPending = !isPreseasonPreparing && !isCollectionReady;
@@ -183,9 +187,7 @@ export async function HomePageContent({
           <p>
             <Info className="h-3.5 w-3.5" aria-hidden="true" />
             <span>
-              {currentPatch === HOME_META_CURRENT_PATCH
-                ? t("collectionPolicyNotice")
-                : t("preseasonPolicyNotice")}
+              {isPreseasonPreparing ? t("preseasonPolicyNotice") : t("collectionPolicyNotice")}
             </span>
           </p>
           {showHomeStats ? (

--- a/frontend/src/data/12.2.ts
+++ b/frontend/src/data/12.2.ts
@@ -1,0 +1,550 @@
+import type { CharacterPatchNote } from "./10.1";
+
+const PATCH = "12.2";
+
+// 출처:
+// - 12.2 패치노트: https://playeternalreturn.com/posts/news/3783?hl=ko-KR
+// 개별 실험체 변경 사항만 기록합니다.
+export const PATCH_NOTES: CharacterPatchNote[] = [
+  {
+    characterCode: 6, // 나딘
+    patch: PATCH,
+    changes: [
+      {
+        target: "석궁 무기 숙련도 레벨 당 기본 공격 증폭",
+        changeType: "nerf",
+        description: ["석궁 나딘의 높은 피해 지표를 견제하기 위해 숙련도 효과를 낮췄습니다."],
+        valueSummary: "1.3% → 1.2%",
+      },
+    ],
+  },
+  {
+    characterCode: 74, // 다르코
+    patch: PATCH,
+    changes: [
+      {
+        target: "기본 공격력",
+        changeType: "nerf",
+        description: ["게임 초중반의 지나치게 강한 교전 능력을 낮췄습니다."],
+        valueSummary: "42 → 40",
+      },
+      {
+        target: "수금(W) - 보호막량",
+        changeType: "nerf",
+        description: ["게임 초중반의 지나치게 강한 교전 능력을 낮췄습니다."],
+        valueSummary: "50/90/130/170/210(+공격력의 55%) → 50/85/120/155/190(+공격력의 55%)",
+      },
+    ],
+  },
+  {
+    characterCode: 65, // 데비&마를렌
+    patch: PATCH,
+    changes: [
+      {
+        target: "레벨 당 방어력",
+        changeType: "buff",
+        description: ["게임 후반의 내구도와 교전 위력을 보완했습니다."],
+        valueSummary: "3 → 3.2",
+      },
+      {
+        target: "휠 댄스(데비 W) - 피해량",
+        changeType: "buff",
+        description: ["게임 후반의 내구도와 교전 위력을 보완했습니다."],
+        valueSummary:
+          "40/70/100/130/160(+추가 공격력의 60%)(+대상 최대 체력의 5/5.5/6/6.5/7%) → 40/70/100/130/160(+추가 공격력의 75%)(+대상 최대 체력의 5/5.5/6/6.5/7%)",
+      },
+    ],
+  },
+  {
+    characterCode: 47, // 라우라
+    patch: PATCH,
+    changes: [
+      {
+        target: "황혼의 도둑(R) - 보호막량",
+        changeType: "nerf",
+        description: ["높은 피해량과 내구도를 함께 갖춘 진입의 위험 부담을 높였습니다."],
+        valueSummary: "90/120/150(+스킬 증폭의 20%) → 80/110/140(+스킬 증폭의 15%)",
+      },
+    ],
+  },
+  {
+    characterCode: 20, // 레녹스
+    patch: PATCH,
+    changes: [
+      {
+        target: "위풍당당(P) - 보호막량",
+        changeType: "buff",
+        description: ["전열에서 버틸 수 있도록 교전 유지력을 높였습니다."],
+        valueSummary: "최대 체력의 7/10/13% → 8/11/14%",
+      },
+    ],
+  },
+  {
+    characterCode: 69, // 레니
+    patch: PATCH,
+    changes: [
+      {
+        target: "레벨 당 방어력",
+        changeType: "buff",
+        description: ["스킬 증폭 아이템 세팅의 내구도와 효율을 보완했습니다."],
+        valueSummary: "2.8 → 3",
+      },
+      {
+        target: "권총 무기 숙련도 레벨 당 스킬 증폭",
+        changeType: "buff",
+        description: ["스킬 증폭 아이템 세팅의 내구도와 효율을 보완했습니다."],
+        valueSummary: "4.2% → 4.4%",
+      },
+      {
+        target: "뿅! 망치(W) - 아군 이동 속도 증가",
+        changeType: "buff",
+        description: ["스킬 증폭 아이템 세팅의 내구도와 효율을 보완했습니다."],
+        valueSummary: "12/14/16/18/20(+스킬 증폭의 2%)% → 12/14/16/18/20(+스킬 증폭의 2.5%)%",
+      },
+    ],
+  },
+  {
+    characterCode: 21, // 로지
+    patch: PATCH,
+    changes: [
+      {
+        target: "스핀샷(W) - 방어력 감소",
+        changeType: "buff",
+        description: ["근접 실험체를 상대할 때의 교전 능력을 높였습니다."],
+        valueSummary: "8/9/10/11/12% → 10/11/12/13/14%",
+      },
+      {
+        target: "셈텍스 탄 Mk-II(R) - 즉시 폭발 피해량",
+        changeType: "buff",
+        description: ["근접 실험체를 상대할 때의 교전 능력을 높였습니다."],
+        valueSummary: "대상 최대 체력의 6/9/12% → 7/10/13%",
+      },
+    ],
+  },
+  {
+    characterCode: 75, // 르노어
+    patch: PATCH,
+    changes: [
+      {
+        target: "스타카토(Q) - 동일 대상 연속 적중 피해 감소",
+        changeType: "buff",
+        description: ["내구도가 높은 대상을 상대할 때의 피해 감소 페널티를 완화했습니다."],
+        valueSummary: "55% → 50%",
+      },
+    ],
+  },
+  {
+    characterCode: 45, // 마이
+    patch: PATCH,
+    changes: [
+      {
+        target: "숄 장막(W) - 받는 피해 감소",
+        changeType: "buff",
+        description: ["낮은 지표를 보완하기 위해 게임 후반 내구도를 높였습니다."],
+        valueSummary: "25/27/29/31/33% → 25/28/31/34/37%",
+      },
+    ],
+  },
+  {
+    characterCode: 53, // 마커스
+    patch: PATCH,
+    changes: [
+      {
+        target: "전투 교범(Q) - 체력 회복량",
+        changeType: "nerf",
+        description: ["높은 내구도와 지속 교전 능력을 일부 낮췄습니다."],
+        valueSummary: "입힌 피해량의 130% → 120%",
+      },
+    ],
+  },
+  {
+    characterCode: 4, // 매그너스
+    patch: PATCH,
+    changes: [
+      {
+        target: "기본 체력",
+        changeType: "nerf",
+        description: ["게임 초반의 지나치게 강한 교전 능력을 견제했습니다."],
+        valueSummary: "1070 → 1030",
+      },
+    ],
+  },
+  {
+    characterCode: 64, // 바냐
+    patch: PATCH,
+    changes: [
+      {
+        target: "몽환 나비(P) - 보호막량",
+        changeType: "nerf",
+        description: [
+          "아르카나 무기 스킬로 높아진 보호막 생성 빈도를 반영해 보호막량을 낮췄습니다.",
+        ],
+        valueSummary: "30/65/100(+스킬 증폭의 30%) → 30/60/90(+스킬 증폭의 30%)",
+      },
+    ],
+  },
+  {
+    characterCode: 84, // 블레어
+    patch: PATCH,
+    changes: [
+      {
+        target: "레벨 당 체력",
+        changeType: "buff",
+        description: ["전반적으로 낮은 지표를 보완하기 위해 기본 성능을 높였습니다."],
+        valueSummary: "86 → 89",
+      },
+    ],
+  },
+  {
+    characterCode: 88, // 비형
+    patch: PATCH,
+    changes: [
+      {
+        target: "신명나게 놀아보자!(R) - 시전 중 받는 피해 감소",
+        changeType: "buff",
+        description: ["궁극기를 보다 안정적으로 시전할 수 있도록 내구도를 높였습니다."],
+        valueSummary: "30% → 40%",
+      },
+    ],
+  },
+  {
+    characterCode: 28, // 수아
+    patch: PATCH,
+    changes: [
+      {
+        target: "마음의 양식(P) - 피해량",
+        changeType: "nerf",
+        description: ["스킬 개편 이후 이어진 강세를 낮추고 대응 여지를 늘렸습니다."],
+        valueSummary: "100/160/220(+스킬 증폭의 50%) → 70/120/170(+스킬 증폭의 50%)",
+      },
+      {
+        target: "오딧세이(Q) - 책 충돌 지점 이동 속도 감소",
+        changeType: "nerf",
+        description: ["스킬 적중 후에도 벗어날 수 있도록 둔화량을 낮췄습니다."],
+        valueSummary: "50/55/60/65/70% → 40/45/50/55/60%",
+      },
+      {
+        target: "돈키호테(E) - 이동 속도 감소",
+        changeType: "nerf",
+        description: ["스킬 적중 후에도 벗어날 수 있도록 둔화량을 낮췄습니다."],
+        valueSummary: "50% → 30%",
+      },
+    ],
+  },
+  {
+    characterCode: 24, // 아델라
+    patch: PATCH,
+    changes: [
+      {
+        target: "레이피어 무기 숙련도 레벨 당 스킬 증폭",
+        changeType: "buff",
+        description: ["상대적으로 낮은 레이피어 지표를 보완했습니다."],
+        valueSummary: "4.6% → 4.7%",
+      },
+    ],
+  },
+  {
+    characterCode: 17, // 아드리아나
+    patch: PATCH,
+    changes: [
+      {
+        target: "레벨 당 체력",
+        changeType: "nerf",
+        description: ["높은 승률과 점수 획득량을 기록한 생존 능력을 견제했습니다."],
+        valueSummary: "76 → 74",
+      },
+    ],
+  },
+  {
+    characterCode: 52, // 아디나
+    patch: PATCH,
+    changes: [
+      {
+        target: "루미너리(Q) - 해 천체 추가 피해량",
+        changeType: "buff",
+        description: ["다른 천체보다 효율이 낮았던 해 천체 효과를 강화했습니다."],
+        valueSummary: "20(+스킬 증폭의 15%) → 30(+스킬 증폭의 25%)",
+      },
+      {
+        target: "트라인 에스펙트(W) - 해 천체 추가 피해량",
+        changeType: "buff",
+        description: ["다른 천체보다 효율이 낮았던 해 천체 효과를 강화했습니다."],
+        valueSummary: "20(+스킬 증폭의 15%) → 30(+스킬 증폭의 25%)",
+      },
+      {
+        target: "폴 디그니티(E) - 해 천체 추가 피해량",
+        changeType: "buff",
+        description: ["다른 천체보다 효율이 낮았던 해 천체 효과를 강화했습니다."],
+        valueSummary: "10(+스킬 증폭의 10%) → 20(+스킬 증폭의 15%)",
+      },
+    ],
+  },
+  {
+    characterCode: 66, // 아르다
+    patch: PATCH,
+    changes: [
+      {
+        target: "바빌론의 입방체(W) - 1타 피해량",
+        changeType: "buff",
+        description: ["낮아진 평균 피해량을 보완했으며 바빌론의 주사위(RW)에도 적용됩니다."],
+        valueSummary: "60/80/100/120/140(+스킬 증폭의 45%) → 60/80/100/120/140(+스킬 증폭의 50%)",
+      },
+    ],
+  },
+  {
+    characterCode: 9, // 아이솔
+    patch: PATCH,
+    changes: [
+      {
+        target: "기본 체력",
+        changeType: "buff",
+        description: ["낮은 내구도와 전반적인 지표를 보완했습니다."],
+        valueSummary: "900 → 920",
+      },
+      {
+        target: "셈텍스 폭탄(Q) - 피해량",
+        changeType: "buff",
+        description: ["스킬 적중 시 보다 확실한 피해를 줄 수 있도록 공격력 계수를 높였습니다."],
+        valueSummary:
+          "60/85/110/135/160(+공격력의 25%)(+스킬 증폭의 70%) → 60/85/110/135/160(+공격력의 35%)(+스킬 증폭의 70%)",
+      },
+    ],
+  },
+  {
+    characterCode: 35, // 얀
+    patch: PATCH,
+    changes: [
+      {
+        target: "위빙(E) - 피해량",
+        changeType: "buff",
+        description: ["톤파 얀의 낮은 지표를 보완하기 위해 스킬 증폭 계수를 높였습니다."],
+        valueSummary:
+          "20/30/40/50/60(+추가 공격력의 100%)(+스킬 증폭의 50%)(+적 최대 체력의 5%) → 20/30/40/50/60(+추가 공격력의 100%)(+스킬 증폭의 60%)(+적 최대 체력의 5%)",
+      },
+    ],
+  },
+  {
+    characterCode: 46, // 에이든
+    patch: PATCH,
+    changes: [
+      {
+        target: "과전하(P) - 종료 시 이동 속도 증가",
+        changeType: "buff",
+        description: ["낮은 점수 획득량을 보완하고 포지셔닝을 돕도록 이동 속도를 높였습니다."],
+        valueSummary: "7/10/13% → 10/13/16%",
+      },
+    ],
+  },
+  {
+    characterCode: 41, // 요한
+    patch: PATCH,
+    changes: [
+      {
+        target: "인도하는 빛(E) - 이동 속도 증가",
+        changeType: "buff",
+        description: ["낮아진 교전 기여도와 아군 보조 능력을 강화했습니다."],
+        valueSummary: "6/8/10/12/14(+스킬 증폭의 1%)% → 6/8/10/12/14(+스킬 증폭의 2%)%",
+      },
+    ],
+  },
+  {
+    characterCode: 36, // 이바
+    patch: PATCH,
+    changes: [
+      {
+        target: "VF 방출(R) - 피해량",
+        changeType: "nerf",
+        description: ["높은 승률과 점수 획득량을 유지한 후반 위력을 낮췄습니다."],
+        valueSummary: "8/12/16(+스킬 증폭의 5%) → 6/10/14(+스킬 증폭의 5%)",
+      },
+      {
+        target: "VF 방출(R) - 5스택 추가 피해량",
+        changeType: "nerf",
+        description: ["높은 승률과 점수 획득량을 유지한 후반 위력을 낮췄습니다."],
+        valueSummary: "30/50/70(+스킬 증폭의 30%) → 30/45/60(+스킬 증폭의 30%)",
+      },
+    ],
+  },
+  {
+    characterCode: 63, // 이안
+    patch: PATCH,
+    changes: [
+      {
+        target: "해방(R) - 공포 지속 시간",
+        changeType: "nerf",
+        description: ["지속적으로 평균 이상이었던 교전 영향력을 낮췄습니다."],
+        valueSummary: "0.9/1.1/1.3초 → 0.9/1/1.1초",
+      },
+    ],
+  },
+  {
+    characterCode: 5, // 자히르
+    patch: PATCH,
+    changes: [
+      {
+        target: "암기 무기 숙련도 레벨 당 스킬 증폭",
+        changeType: "buff",
+        description: ["상대적으로 낮은 암기 지표를 보완했습니다."],
+        valueSummary: "3.9% → 4%",
+      },
+    ],
+  },
+  {
+    characterCode: 1, // 재키
+    patch: PATCH,
+    changes: [
+      {
+        target: "단검 무기 숙련도 레벨 당 기본 공격 증폭",
+        changeType: "nerf",
+        description: ["무기군별 성능 격차를 줄이기 위해 강한 무기 숙련도를 낮췄습니다."],
+        valueSummary: "2.8% → 2.4%",
+      },
+      {
+        target: "양손검 무기 숙련도 레벨 당 기본 공격 증폭",
+        changeType: "nerf",
+        description: ["무기군별 성능 격차를 줄이기 위해 강한 무기 숙련도를 낮췄습니다."],
+        valueSummary: "2.3% → 2.2%",
+      },
+      {
+        target: "도끼 무기 숙련도 레벨 당 기본 공격 증폭",
+        changeType: "buff",
+        description: ["무기군별 성능 격차를 줄이기 위해 낮은 도끼 지표를 보완했습니다."],
+        valueSummary: "1.9% → 2.1%",
+      },
+    ],
+  },
+  {
+    characterCode: 38, // 제니
+    patch: PATCH,
+    changes: [
+      {
+        target: "페르소나(E) - 피해량",
+        changeType: "buff",
+        description: ["낮은 스킬 증폭 계수를 소폭 높여 피해 능력을 보완했습니다."],
+        valueSummary: "60/95/130/165/200(+스킬 증폭의 58%) → 60/95/130/165/200(+스킬 증폭의 60%)",
+      },
+    ],
+  },
+  {
+    characterCode: 39, // 카밀로
+    patch: PATCH,
+    changes: [
+      {
+        target: "씨에레(W) - 피해량",
+        changeType: "nerf",
+        description: ["대부분의 구간에서 기록한 매우 높은 지표를 낮췄습니다."],
+        valueSummary:
+          "5/15/25/35/45(+공격력의 20%) × 기본 공격 증폭 → 5/15/25/35/45(+공격력의 18%) × 기본 공격 증폭",
+      },
+    ],
+  },
+  {
+    characterCode: 54, // 칼라
+    patch: PATCH,
+    changes: [
+      {
+        target: "작살 장전(P) - 장전 게이지 충전 시간",
+        changeType: "nerf",
+        description: ["강한 성능과 과도한 저지 능력을 낮추기 위해 발동 빈도를 줄였습니다."],
+        valueSummary: "13/11/9초 → 14/12/10초",
+      },
+      {
+        target: "구속의 사슬(R) - 이동 속도 감소",
+        changeType: "nerf",
+        description: ["강한 성능과 과도한 저지 능력을 낮췄습니다."],
+        valueSummary: "40/45/50% → 30/35/40%",
+      },
+    ],
+  },
+  {
+    characterCode: 40, // 클로에
+    patch: PATCH,
+    changes: [
+      {
+        target: "살아 있는 마리오네트(P) - 니나 추가 방어력",
+        changeType: "buff",
+        description: ["니나의 내구도와 자체 전투 능력을 강화했습니다."],
+        valueSummary: "15/30/45 → 20/35/50",
+      },
+      {
+        target: "공격 명령(Q) - 피해량",
+        changeType: "buff",
+        description: ["니나의 내구도와 자체 전투 능력을 강화했습니다."],
+        valueSummary:
+          "70/90/110/130/150(+니나 공격력의 75%) → 70/90/110/130/150(+니나 공격력의 80%)",
+      },
+    ],
+  },
+  {
+    characterCode: 60, // 타지아
+    patch: PATCH,
+    changes: [
+      {
+        target: "파라디소(R) - 대검 적중 피해량",
+        changeType: "buff",
+        description: ["스킬 난이도에 맞게 대검 적중 시의 보상을 높였습니다."],
+        valueSummary: "60/100/140(+스킬 증폭의 40%) → 70/120/170(+스킬 증폭의 45%)",
+      },
+    ],
+  },
+  {
+    characterCode: 51, // 프리야
+    patch: PATCH,
+    changes: [
+      {
+        target: "대지의 메아리(R) - 피해량",
+        changeType: "buff",
+        description: ["지나치게 낮아진 평균 피해량을 보완했습니다."],
+        valueSummary: "80/150/220(+스킬 증폭의 60%) → 80/150/220(+스킬 증폭의 65%)",
+      },
+    ],
+  },
+  {
+    characterCode: 3, // 피오라
+    patch: PATCH,
+    changes: [
+      {
+        target: "레이피어 무기 숙련도 레벨 당 스킬 증폭",
+        changeType: "nerf",
+        description: ["매우 높은 점수 획득량을 기록한 레이피어의 숙련도 효과를 낮췄습니다."],
+        valueSummary: "4.2% → 4.1%",
+      },
+    ],
+  },
+  {
+    characterCode: 83, // 헨리
+    patch: PATCH,
+    changes: [
+      {
+        target: "시간 도약(E) - 피해량",
+        changeType: "buff",
+        description: ["공격적인 스킬 연계를 성공시켰을 때의 보상을 높였습니다."],
+        valueSummary: "40/80/120/160/200(+스킬 증폭의 60%) → 40/80/120/160/200(+스킬 증폭의 70%)",
+      },
+    ],
+  },
+  {
+    characterCode: 7, // 현우
+    patch: PATCH,
+    changes: [
+      {
+        target: "도그파이트(P) - 체력 회복량",
+        changeType: "buff",
+        description: ["오랜 기간 이어진 약세를 보완하기 위해 회복량을 높였습니다."],
+        valueSummary: "최대 체력의 5/8/11% → 6/9/12%",
+      },
+    ],
+  },
+  {
+    characterCode: 78, // 히스이
+    patch: PATCH,
+    changes: [
+      {
+        target: "거합일섬(W) - 일륜난무(W3) 피해량",
+        changeType: "buff",
+        description: ["활용도가 낮았던 일륜난무의 가치를 높였습니다."],
+        valueSummary: "10(+추가 공격력의 15/20/25/30/35%) → 20(+추가 공격력의 15/20/25/30/35%)",
+      },
+    ],
+  },
+];

--- a/frontend/src/data/patch-notes.ts
+++ b/frontend/src/data/patch-notes.ts
@@ -16,6 +16,7 @@ import { PATCH_NOTES as PATCH_11_6 } from "./11.6";
 import { PATCH_NOTES as PATCH_11_7 } from "./11.7";
 import { PATCH_NOTES as PATCH_12_0 } from "./12.0";
 import { PATCH_NOTES as PATCH_12_1 } from "./12.1";
+import { PATCH_NOTES as PATCH_12_2 } from "./12.2";
 
 export type { ChangeType, PatchChange, CharacterPatchNote } from "./10.1";
 
@@ -37,6 +38,7 @@ export const PATCH_NOTES: CharacterPatchNote[] = [
   ...PATCH_11_7,
   ...PATCH_12_0,
   ...PATCH_12_1,
+  ...PATCH_12_2,
 ];
 
 export function getCharacterPatchNote(

--- a/frontend/src/lib/getPatches.ts
+++ b/frontend/src/lib/getPatches.ts
@@ -1,5 +1,10 @@
 import { unstable_cache } from "next/cache";
 import { getVisibleStatsPatchVersions, isVisibleStatsPatchVersion } from "@/data/patch-notes";
+import {
+  filterReadyStatsPatchVersions,
+  HOME_BASE_TIERS,
+  HOME_META_TARGET_PATCH,
+} from "@/lib/homeMetaShared";
 import { createServerClient } from "@/lib/supabase";
 
 /**
@@ -11,26 +16,42 @@ export const getPatches = unstable_cache(
   async (): Promise<string[]> => {
     try {
       const supabase = createServerClient();
-      const { data, error } = await supabase
-        .from("PatchVersion")
-        .select("version")
-        .eq("isActive", true)
-        .order("startDate", { ascending: false })
-        .limit(10);
+      const [patchResult, collectionResult] = await Promise.all([
+        supabase
+          .from("PatchVersion")
+          .select("version")
+          .eq("isActive", true)
+          .order("startDate", { ascending: false })
+          .limit(10),
+        supabase
+          .from("v2_CharacterStats")
+          .select("totalGames")
+          .eq("patchVersion", HOME_META_TARGET_PATCH)
+          .in("tier", HOME_BASE_TIERS),
+      ]);
 
       const localPatchVersions = getVisibleStatsPatchVersions();
-      if (!error && data && data.length > 0) {
-        const activePatchVersions = data.map((p) => p.version).filter(isVisibleStatsPatchVersion);
-        return Array.from(new Set([...localPatchVersions, ...activePatchVersions]));
+      const targetCollectedGames = collectionResult.error
+        ? 0
+        : (collectionResult.data ?? []).reduce((sum, row) => sum + Number(row.totalGames ?? 0), 0);
+
+      if (!patchResult.error && patchResult.data && patchResult.data.length > 0) {
+        const activePatchVersions = patchResult.data
+          .map((p) => p.version)
+          .filter(isVisibleStatsPatchVersion);
+        return filterReadyStatsPatchVersions(
+          Array.from(new Set([...localPatchVersions, ...activePatchVersions])),
+          targetCollectedGames
+        );
       }
-      return localPatchVersions;
+      return filterReadyStatsPatchVersions(localPatchVersions, targetCollectedGames);
     } catch {
-      return getVisibleStatsPatchVersions();
+      return filterReadyStatsPatchVersions(getVisibleStatsPatchVersions(), 0);
     }
   },
-  ["patches", "patch-notes-v7-visible-from-11-1"],
+  ["patches", "patch-notes-v8-12-2-sample-gate"],
   {
-    revalidate: 21600,
+    revalidate: 900,
     tags: ["patches"],
   }
 );

--- a/frontend/src/lib/homeMetaServer.ts
+++ b/frontend/src/lib/homeMetaServer.ts
@@ -4,7 +4,7 @@ import { createServerClient } from "@/lib/supabase";
 import {
   HOME_BASE_TIERS,
   HOME_META_COMPARISON_PATCH,
-  HOME_META_CURRENT_PATCH,
+  HOME_META_TARGET_PATCH,
   type HomeBaseTier,
   type HomeMetaStatRow,
   type HomeMetaStats,
@@ -68,7 +68,7 @@ async function fetchHomeMetaStats(patchVersion: string): Promise<HomeMetaStats> 
   );
   const currentIndex = patchList.indexOf(patchVersion);
   let previousPatch: string | null =
-    patchVersion === HOME_META_CURRENT_PATCH ? HOME_META_COMPARISON_PATCH : null;
+    patchVersion === HOME_META_TARGET_PATCH ? HOME_META_COMPARISON_PATCH : null;
 
   if (!previousPatch && currentIndex >= 0) {
     for (let i = currentIndex + 1; i < patchList.length; i++) {
@@ -126,7 +126,7 @@ async function fetchHomeMetaStats(patchVersion: string): Promise<HomeMetaStats> 
 export async function getCachedHomeMetaStats(patchVersion: string): Promise<HomeMetaStats> {
   return unstable_cache(
     async () => fetchHomeMetaStats(patchVersion),
-    ["home-meta-stats-v5-11-7-comparison", patchVersion],
+    ["home-meta-stats-v6-12-2-comparison", patchVersion],
     {
       revalidate: 21600,
       tags: ["home-meta-stats", `home-meta-stats:${patchVersion}`],

--- a/frontend/src/lib/homeMetaShared.ts
+++ b/frontend/src/lib/homeMetaShared.ts
@@ -9,9 +9,22 @@ export type HomeSelectableTier = HomeBaseTier | HomePlusTier;
 
 export const DEFAULT_HOME_TIER: HomePlusTier = "DIAMOND_PLUS";
 export const HOME_BASE_TIERS: HomeBaseTier[] = ["DIAMOND", "METEORITE", "MITHRIL"];
-export const HOME_META_CURRENT_PATCH = "12.1";
-export const HOME_META_COMPARISON_PATCH = "11.7";
+export const HOME_META_TARGET_PATCH = "12.2";
+export const HOME_META_FALLBACK_PATCH = "12.1";
+export const HOME_META_COMPARISON_PATCH = HOME_META_FALLBACK_PATCH;
 export const HOME_META_MIN_COLLECTED_GAMES = 50_000;
+
+export function isHomeMetaTargetReady(collectedGames: number): boolean {
+  return collectedGames >= HOME_META_MIN_COLLECTED_GAMES;
+}
+
+export function filterReadyStatsPatchVersions(
+  patches: string[],
+  targetCollectedGames: number
+): string[] {
+  if (isHomeMetaTargetReady(targetCollectedGames)) return patches;
+  return patches.filter((patch) => patch !== HOME_META_TARGET_PATCH);
+}
 
 export const HOME_PLUS_TIER_MAP: Record<HomePlusTier, HomeBaseTier[]> = {
   DIAMOND_PLUS: ["DIAMOND", "METEORITE", "MITHRIL"],


### PR DESCRIPTION
## Summary

- 공식 12.2 패치노트의 실험체 37명, 변경 52건을 반영했습니다.
- 12.2 다이아 이상 데이터가 50,000게임 미만이면 12.1을 기본 통계로 유지합니다.
- 기준 충족 후 15분 이내 홈/실험체/API 기본 패치를 12.2로 전환합니다.
- 공개 정책 안내와 회귀 테스트를 추가했습니다.

## Test plan

- [x] Vitest 전체 232개 통과
- [x] 관련 파일 ESLint 통과
- [x] `tsc --noEmit` 통과
- [x] Next.js 프로덕션 빌드 통과

Closes #212