### PR TITLE
[fix] 12.2 공개 판수에 8배 환산 적용

### DIFF
--- a/frontend/src/__tests__/homeMetaShared.test.ts
+++ b/frontend/src/__tests__/homeMetaShared.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildHomeMetaView,
   filterReadyStatsPatchVersions,
+  getHomeMetaQualificationGames,
   HOME_META_MIN_COLLECTED_GAMES,
   type HomeMetaStats,
 } from "@/lib/homeMetaShared";
@@ -60,14 +61,16 @@ describe("buildHomeMetaView cumulative tiers", () => {
 describe("latest stats patch sample gate", () => {
   const patches = ["12.2", "12.1", "11.7"];
 
-  it("기준 판수 전에는 12.1을 최신 통계 패치로 유지한다", () => {
-    expect(filterReadyStatsPatchVersions(patches, HOME_META_MIN_COLLECTED_GAMES - 1)).toEqual([
-      "12.1",
-      "11.7",
-    ]);
+  it("원본 수집량에 8배 환산을 적용한다", () => {
+    expect(getHomeMetaQualificationGames(6_249)).toBe(49_992);
+    expect(getHomeMetaQualificationGames(6_250)).toBe(HOME_META_MIN_COLLECTED_GAMES);
   });
 
-  it("기준 판수를 채우면 12.2를 최신 통계 패치로 공개한다", () => {
-    expect(filterReadyStatsPatchVersions(patches, HOME_META_MIN_COLLECTED_GAMES)).toEqual(patches);
+  it("환산 기준 판수 전에는 12.1을 최신 통계 패치로 유지한다", () => {
+    expect(filterReadyStatsPatchVersions(patches, 6_249)).toEqual(["12.1", "11.7"]);
+  });
+
+  it("환산 기준 판수를 채우면 12.2를 최신 통계 패치로 공개한다", () => {
+    expect(filterReadyStatsPatchVersions(patches, 6_250)).toEqual(patches);
   });
 });

--- a/frontend/src/components/features/home/HomePageContent.tsx
+++ b/frontend/src/components/features/home/HomePageContent.tsx
@@ -13,6 +13,7 @@ import { getTranslations } from "next-intl/server";
 import { CharacterSearchCombobox } from "@/components/features/character-analysis/CharacterSearchCombobox";
 import type { HomeMetaStats } from "@/lib/homeMetaShared";
 import {
+  getHomeMetaQualificationGames,
   HOME_META_FALLBACK_PATCH,
   HOME_META_MIN_COLLECTED_GAMES,
   HOME_META_TARGET_PATCH,
@@ -47,12 +48,13 @@ export async function HomePageContent({
   const defaultPatch = patches[0] ?? "";
   const rankingGames = rankingData.rankings.reduce((sum, row) => sum + row.totalGames, 0);
   const collectedGames = homeMetaStats.collectedGames ?? 0;
+  const qualificationGames = getHomeMetaQualificationGames(collectedGames);
   const hasRankingData = rankingData.rankings.length > 0 && rankingGames > 0;
   const isCollectionReady =
     homeMetaStats.patchVersion !== HOME_META_TARGET_PATCH || isHomeMetaTargetReady(collectedGames);
   const collectionProgress = Math.min(
     100,
-    Math.floor((collectedGames / HOME_META_MIN_COLLECTED_GAMES) * 100)
+    Math.floor((qualificationGames / HOME_META_MIN_COLLECTED_GAMES) * 100)
   );
   const trackedMatches = isCollectionReady
     ? formatMetricNumber(collectedGames / ESTIMATED_PARTICIPANTS_PER_MATCH)

--- a/frontend/src/lib/getPatches.ts
+++ b/frontend/src/lib/getPatches.ts
@@ -49,7 +49,7 @@ export const getPatches = unstable_cache(
       return filterReadyStatsPatchVersions(getVisibleStatsPatchVersions(), 0);
     }
   },
-  ["patches", "patch-notes-v8-12-2-sample-gate"],
+  ["patches", "patch-notes-v9-12-2-sample-gate-x8"],
   {
     revalidate: 900,
     tags: ["patches"],

--- a/frontend/src/lib/homeMetaShared.ts
+++ b/frontend/src/lib/homeMetaShared.ts
@@ -13,9 +13,14 @@ export const HOME_META_TARGET_PATCH = "12.2";
 export const HOME_META_FALLBACK_PATCH = "12.1";
 export const HOME_META_COMPARISON_PATCH = HOME_META_FALLBACK_PATCH;
 export const HOME_META_MIN_COLLECTED_GAMES = 50_000;
+export const HOME_META_COLLECTION_MULTIPLIER = 8;
+
+export function getHomeMetaQualificationGames(collectedGames: number): number {
+  return collectedGames * HOME_META_COLLECTION_MULTIPLIER;
+}
 
 export function isHomeMetaTargetReady(collectedGames: number): boolean {
-  return collectedGames >= HOME_META_MIN_COLLECTED_GAMES;
+  return getHomeMetaQualificationGames(collectedGames) >= HOME_META_MIN_COLLECTED_GAMES;
 }
 
 export function filterReadyStatsPatchVersions(


### PR DESCRIPTION
## Summary

- 12.2 통계 공개 판정을 DB 원본 수집량 × 8 기준으로 변경했습니다.
- 홈 공개 진행률에도 동일한 환산값을 적용했습니다.
- 배포 후 이전 패치 목록 캐시를 재사용하지 않도록 캐시 키를 갱신했습니다.
- 원본 6,249는 미공개, 6,250은 공개되는 경계값 테스트를 추가했습니다.

## Test plan

- [x] `homeMetaShared.test.ts` 6개 통과
- [x] 변경 파일 ESLint 통과
- [x] `tsc --noEmit` 통과

Closes #214