### PR TITLE
[fix] 시즌 리캡 공지 배너 스크롤 진동 방지

### DIFF
--- a/frontend/src/__tests__/announcementScroll.test.ts
+++ b/frontend/src/__tests__/announcementScroll.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  ANNOUNCEMENT_COLLAPSE_SCROLL_Y,
+  ANNOUNCEMENT_EXPAND_SCROLL_Y,
+  resolveAnnouncementCollapsed,
+} from "@/components/layout/announcementScroll";
+
+describe("resolveAnnouncementCollapsed", () => {
+  it("keeps an expanded announcement open inside the collapse threshold", () => {
+    expect(
+      resolveAnnouncementCollapsed({
+        currentlyCollapsed: false,
+        scrollY: ANNOUNCEMENT_COLLAPSE_SCROLL_Y,
+        hasFocus: false,
+      })
+    ).toBe(false);
+  });
+
+  it("keeps a collapsed announcement closed after scroll anchoring reduces scrollY", () => {
+    expect(
+      resolveAnnouncementCollapsed({
+        currentlyCollapsed: true,
+        scrollY: ANNOUNCEMENT_COLLAPSE_SCROLL_Y - 44,
+        hasFocus: false,
+      })
+    ).toBe(true);
+  });
+
+  it("expands again only near the top of the page", () => {
+    expect(
+      resolveAnnouncementCollapsed({
+        currentlyCollapsed: true,
+        scrollY: ANNOUNCEMENT_EXPAND_SCROLL_Y,
+        hasFocus: false,
+      })
+    ).toBe(false);
+  });
+
+  it("stays expanded while the announcement contains focus", () => {
+    expect(
+      resolveAnnouncementCollapsed({
+        currentlyCollapsed: true,
+        scrollY: 500,
+        hasFocus: true,
+      })
+    ).toBe(false);
+  });
+});

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -25,6 +25,7 @@ import { useTranslations } from "next-intl";
 import * as React from "react";
 import { CharacterSearchCombobox } from "@/components/features/character-analysis/CharacterSearchCombobox";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import { resolveAnnouncementCollapsed } from "@/components/layout/announcementScroll";
 import { LocaleRecommendationBanner } from "@/components/layout/LocaleRecommendationBanner";
 import { Navigation } from "@/components/layout/Navigation";
 import { IntentPrefetchLink } from "@/components/navigation/IntentPrefetchLink";
@@ -132,8 +133,14 @@ export function Header({ currentPatch, patchAnalysisPatch }: HeaderProps) {
     }
 
     const syncAnnouncement = () => {
-      const announcementHasFocus = document.activeElement?.closest(".site-announcement");
-      setAnnouncementCollapsed(window.scrollY > 48 && !announcementHasFocus);
+      const announcementHasFocus = Boolean(document.activeElement?.closest(".site-announcement"));
+      setAnnouncementCollapsed((currentlyCollapsed) =>
+        resolveAnnouncementCollapsed({
+          currentlyCollapsed,
+          scrollY: window.scrollY,
+          hasFocus: announcementHasFocus,
+        })
+      );
     };
 
     syncAnnouncement();

--- a/frontend/src/components/layout/announcementScroll.ts
+++ b/frontend/src/components/layout/announcementScroll.ts
@@ -1,0 +1,20 @@
+export const ANNOUNCEMENT_COLLAPSE_SCROLL_Y = 96;
+export const ANNOUNCEMENT_EXPAND_SCROLL_Y = 16;
+
+interface ResolveAnnouncementCollapsedArgs {
+  currentlyCollapsed: boolean;
+  scrollY: number;
+  hasFocus: boolean;
+}
+
+export function resolveAnnouncementCollapsed({
+  currentlyCollapsed,
+  scrollY,
+  hasFocus,
+}: ResolveAnnouncementCollapsedArgs) {
+  if (hasFocus) return false;
+
+  return currentlyCollapsed
+    ? scrollY > ANNOUNCEMENT_EXPAND_SCROLL_Y
+    : scrollY > ANNOUNCEMENT_COLLAPSE_SCROLL_Y;
+}


### PR DESCRIPTION
## Summary

- 시즌 리캡 공지 배너의 접힘·펼침 임계값을 분리해 스크롤 앵커 보정 구간에서 상태가 반복 전환되지 않도록 했습니다.
- 접힌 상태는 페이지 상단 근처까지 올라왔을 때만 다시 펼치고, 공지 배너에 포커스가 있으면 펼친 상태를 유지합니다.
- 44px 헤더 높이 보정 뒤에도 접힌 상태를 유지하는 회귀 테스트를 추가했습니다.

## Test plan

- [x] `announcementScroll.test.ts` 4개 통과
- [x] 변경 파일 ESLint 통과
- [x] TypeScript `tsc --noEmit --incremental false` 통과
- [x] 모바일 390px 실브라우저에서 기존 `scrollY 55px ↔ 11px` 진동이 사라지고 접힌 상태가 `scrollY 71px`에서 안정적으로 유지되는지 확인
- [x] 홈 배너에서 시즌 11 리캡 진입 시 `scrollY=0`, 이후 `600px → 2200px` 연속 스크롤 확인
- [x] 브라우저 콘솔 오류, Next.js 오류 오버레이, 서버 5xx 없음

Closes #223
