### PR TITLE
[feat] 광고 차단 감지 팝업 A/B 테스트

### DIFF
--- a/frontend/src/__tests__/adBlockRecoveryExperiment.test.ts
+++ b/frontend/src/__tests__/adBlockRecoveryExperiment.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  DISMISS_COOLDOWN_MS,
+  RECOVERY_ATTEMPT_TTL_MS,
+  consumeRecentAdBlockRecoveryAttempt,
+  getOrCreateAdBlockRecoveryVariant,
+  isAdBlockRecoveryPromptSuppressed,
+  markAdBlockRecoveryAttempt,
+  resolveAdBlockRecoveryVariant,
+  suppressAdBlockRecoveryPrompt,
+  type StorageLike,
+} from "../lib/adBlockRecoveryExperiment";
+
+class MemoryStorage implements StorageLike {
+  private values = new Map<string, string>();
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key);
+  }
+}
+
+describe("ad block recovery experiment", () => {
+  it("splits new visitors into a stable 50/50 variant", () => {
+    const contextStorage = new MemoryStorage();
+    expect(getOrCreateAdBlockRecoveryVariant(contextStorage, 0.49)).toBe("context");
+    expect(getOrCreateAdBlockRecoveryVariant(contextStorage, 0.99)).toBe("context");
+
+    const directStorage = new MemoryStorage();
+    expect(getOrCreateAdBlockRecoveryVariant(directStorage, 0.5)).toBe("direct");
+    expect(getOrCreateAdBlockRecoveryVariant(directStorage, 0.01)).toBe("direct");
+  });
+
+  it("supports kill-switch and winner-lock modes", () => {
+    const storage = new MemoryStorage();
+
+    expect(resolveAdBlockRecoveryVariant(storage, "off", 0.1)).toBeNull();
+    expect(resolveAdBlockRecoveryVariant(storage, "context", 0.9)).toBe("context");
+    expect(resolveAdBlockRecoveryVariant(storage, "direct", 0.1)).toBe("direct");
+    expect(resolveAdBlockRecoveryVariant(storage, "experiment", 0.49)).toBe("context");
+    expect(resolveAdBlockRecoveryVariant(storage, "experiment", 0.99)).toBe("context");
+  });
+
+  it("suppresses a dismissed prompt for 24 hours", () => {
+    const storage = new MemoryStorage();
+    const now = Date.UTC(2026, 7, 18);
+
+    suppressAdBlockRecoveryPrompt(storage, now);
+
+    expect(isAdBlockRecoveryPromptSuppressed(storage, now + DISMISS_COOLDOWN_MS - 1)).toBe(true);
+    expect(isAdBlockRecoveryPromptSuppressed(storage, now + DISMISS_COOLDOWN_MS)).toBe(false);
+  });
+
+  it("consumes a recent recovery attempt once", () => {
+    const storage = new MemoryStorage();
+    const now = Date.UTC(2026, 7, 18);
+
+    markAdBlockRecoveryAttempt(storage, {
+      variant: "direct",
+      attemptedAt: now,
+      pagePath: "/ko/patches",
+    });
+
+    expect(consumeRecentAdBlockRecoveryAttempt(storage, now + 1000)).toEqual({
+      variant: "direct",
+      attemptedAt: now,
+      pagePath: "/ko/patches",
+    });
+    expect(consumeRecentAdBlockRecoveryAttempt(storage, now + 1000)).toBeNull();
+  });
+
+  it("rejects stale recovery attempts", () => {
+    const storage = new MemoryStorage();
+    const now = Date.UTC(2026, 7, 18);
+
+    markAdBlockRecoveryAttempt(storage, {
+      variant: "context",
+      attemptedAt: now - RECOVERY_ATTEMPT_TTL_MS - 1,
+      pagePath: "/",
+    });
+
+    expect(consumeRecentAdBlockRecoveryAttempt(storage, now)).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/analytics.test.ts
+++ b/frontend/src/__tests__/analytics.test.ts
@@ -25,8 +25,9 @@ const sessionStorage = new MemoryStorage();
 
 // ── @amplitude/analytics-browser mock ────────────────────────────────────────
 // vi.mock 은 hoisted 되므로, 외부 참조 변수는 vi.hoisted 로 감싸야 안전하다.
-const { trackMock, identifyMock, IdentifyMock } = vi.hoisted(() => {
+const { trackMock, vercelTrackMock, identifyMock, IdentifyMock } = vi.hoisted(() => {
   const trackMock = vi.fn();
+  const vercelTrackMock = vi.fn();
   const identifyMock = vi.fn();
   class IdentifyMock {
     private props: Record<string, unknown> = {};
@@ -38,7 +39,7 @@ const { trackMock, identifyMock, IdentifyMock } = vi.hoisted(() => {
       return this.props;
     }
   }
-  return { trackMock, identifyMock, IdentifyMock };
+  return { trackMock, vercelTrackMock, identifyMock, IdentifyMock };
 });
 
 vi.mock("@amplitude/analytics-browser", () => ({
@@ -47,11 +48,16 @@ vi.mock("@amplitude/analytics-browser", () => ({
   Identify: IdentifyMock,
 }));
 
+vi.mock("@vercel/analytics", () => ({
+  track: vercelTrackMock,
+}));
+
 // analytics.ts 는 getAmplitude 의 promise 를 module-scope 에 캐시하므로
 // 여러 테스트가 동일한 mock 을 공유한다. clearAllMocks 로 호출 기록만 리셋.
 
 beforeEach(() => {
   trackMock.mockClear();
+  vercelTrackMock.mockClear();
   identifyMock.mockClear();
   window.sessionStorage.clear();
 });
@@ -67,6 +73,28 @@ async function flushAsync() {
 }
 
 describe("analytics — P0 helpers", () => {
+  describe("ad block recovery funnel", () => {
+    it("Amplitude와 Vercel에 동일한 실험 노출 이벤트를 보낸다", async () => {
+      analytics.adBlockRecoveryPromptShown({
+        variant: "direct",
+        locale: "ko",
+        pagePath: "/ko/patches",
+        detectionMethod: "cosmetic_bait",
+      });
+      await flushAsync();
+
+      const properties = {
+        experiment: "adblock_recovery_prompt_v1",
+        variant: "direct",
+        locale: "ko",
+        page_path: "/ko/patches",
+        detection_method: "cosmetic_bait",
+      };
+      expect(trackMock).toHaveBeenCalledWith("ad_block_recovery_prompt_shown", properties);
+      expect(vercelTrackMock).toHaveBeenCalledWith("ad_block_recovery_prompt_shown", properties);
+    });
+  });
+
   describe("coreFeatureUsed (NSM dedupe)", () => {
     it("세션 내 첫 호출은 firstTimeInSession=true 로 fire 한다", async () => {
       analytics.coreFeatureUsed("character_analysis");

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2547,6 +2547,374 @@ body,
   }
 }
 
+/* Hallmark · component: modal · genre: modern-minimal · theme: custom Mineral Signal
+ * states: default · hover · focus · active · disabled · loading · error · success
+ * pre-emit critique: P5 H5 E5 S5 R5 V4 · contrast: pass (40–41)
+ */
+.ad-recovery-dialog {
+  position: fixed;
+  inset: 0;
+  width: min(30rem, calc(100% - var(--space-xl)));
+  height: fit-content;
+  max-height: min(80dvh, 40rem);
+  margin: auto;
+  overflow: auto;
+  border: var(--rule-hair) solid var(--color-rule-2);
+  border-radius: var(--radius-card);
+  background: var(--color-paper);
+  padding: 0;
+  color: var(--color-ink);
+  box-shadow: var(--shadow-card);
+  animation: ad-recovery-enter var(--dur-short) var(--ease-out) both;
+}
+
+.ad-recovery-dialog::backdrop {
+  background: color-mix(in oklch, var(--color-graphite) 72%, transparent);
+  animation: ad-recovery-backdrop var(--dur-short) var(--ease-out) both;
+}
+
+.ad-recovery-panel {
+  min-width: 0;
+  background: var(--color-paper);
+  color: var(--color-ink);
+  font-family: var(--font-body);
+}
+
+.ad-recovery-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  padding: var(--space-md) var(--space-md) 0;
+}
+
+.ad-recovery-panel__signal,
+.ad-recovery-panel__close {
+  display: grid;
+  width: calc(var(--space-xl) + var(--space-2xs));
+  height: calc(var(--space-xl) + var(--space-2xs));
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: var(--radius-input);
+}
+
+.ad-recovery-panel__signal {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+.ad-recovery-panel__signal svg {
+  width: var(--space-lg);
+  height: var(--space-lg);
+}
+
+.ad-recovery-panel__close {
+  border: var(--rule-hair) solid transparent;
+  background: transparent;
+  color: var(--color-muted);
+  cursor: pointer;
+  transition:
+    background-color var(--dur-micro) var(--ease-out),
+    color var(--dur-micro) var(--ease-out),
+    transform var(--dur-micro) var(--ease-out);
+}
+
+.ad-recovery-panel__close svg {
+  width: var(--space-md);
+  height: var(--space-md);
+}
+
+.ad-recovery-panel__copy {
+  display: grid;
+  gap: var(--space-sm);
+  padding: var(--space-md) var(--space-lg) var(--space-lg);
+}
+
+.ad-recovery-panel__copy h2 {
+  min-width: 0;
+  color: var(--color-ink);
+  font-family: var(--font-display);
+  font-size: var(--text-lg);
+  font-style: normal;
+  font-weight: var(--display-weight);
+  letter-spacing: var(--tracking-display);
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+.ad-recovery-panel__copy p {
+  max-width: 58ch;
+  color: var(--color-neutral);
+  font-size: var(--text-base);
+  line-height: 1.6;
+}
+
+.ad-recovery-panel__instruction {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: start;
+  gap: var(--space-sm);
+  border-block: var(--rule-hair) solid var(--color-rule);
+  background: var(--color-paper-2);
+  padding: var(--space-md) var(--space-lg);
+  color: var(--color-neutral);
+}
+
+.ad-recovery-panel__instruction > span {
+  display: grid;
+  width: var(--space-lg);
+  height: var(--space-lg);
+  place-items: center;
+  border: var(--rule-hair) solid var(--color-rule-2);
+  border-radius: var(--radius-pill);
+  color: var(--color-accent);
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+}
+
+.ad-recovery-panel__instruction p {
+  min-width: 0;
+  font-size: var(--text-sm);
+  line-height: 1.55;
+}
+
+.ad-recovery-panel__actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-lg) var(--space-lg) var(--space-sm);
+}
+
+.ad-recovery-panel__primary,
+.ad-recovery-panel__later {
+  display: inline-flex;
+  min-height: calc(var(--space-xl) + var(--space-2xs));
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs);
+  border: var(--rule-hair) solid transparent;
+  border-radius: var(--radius-button);
+  padding-inline: var(--space-md);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    border-color var(--dur-micro) var(--ease-out),
+    background-color var(--dur-micro) var(--ease-out),
+    color var(--dur-micro) var(--ease-out),
+    transform var(--dur-micro) var(--ease-out);
+}
+
+.ad-recovery-panel__primary {
+  background: var(--color-accent);
+  color: var(--color-accent-ink);
+}
+
+.ad-recovery-panel__later {
+  border-color: var(--color-rule-2);
+  background: var(--color-paper);
+  color: var(--color-neutral);
+}
+
+.ad-recovery-panel__primary svg,
+.ad-recovery-panel__later svg {
+  width: var(--space-md);
+  height: var(--space-md);
+  flex: 0 0 auto;
+}
+
+.ad-recovery-panel__primary:focus-visible,
+.ad-recovery-panel__later:focus-visible,
+.ad-recovery-panel__close:focus-visible,
+.ad-recovery-panel[data-ui-state="focus"] .ad-recovery-panel__primary {
+  outline: var(--rule-fine) solid var(--color-focus);
+  outline-offset: var(--space-2xs);
+}
+
+.ad-recovery-panel__primary:active,
+.ad-recovery-panel__later:active,
+.ad-recovery-panel__close:active,
+.ad-recovery-panel[data-ui-state="active"] .ad-recovery-panel__primary {
+  transform: translateY(var(--rule-hair));
+}
+
+.ad-recovery-panel__primary:disabled,
+.ad-recovery-panel__later:disabled,
+.ad-recovery-panel__close:disabled,
+.ad-recovery-panel[data-ui-state="disabled"] .ad-recovery-panel__primary {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.ad-recovery-panel[data-ui-state="loading"] .ad-recovery-panel__primary {
+  cursor: progress;
+}
+
+.ad-recovery-panel[data-ui-state="error"] .ad-recovery-panel__primary {
+  border-color: var(--color-danger);
+  background: var(--color-paper);
+  color: var(--color-danger);
+}
+
+.ad-recovery-panel[data-ui-state="success"] .ad-recovery-panel__primary {
+  border-color: var(--color-success);
+  background: var(--color-success-soft);
+  color: var(--color-success);
+}
+
+.ad-recovery-panel__spinner {
+  animation: ad-recovery-spin 1s linear infinite;
+}
+
+.ad-recovery-panel__status {
+  display: flex;
+  min-height: 1.55em;
+  align-items: flex-start;
+  gap: var(--space-xs);
+  padding-inline: var(--space-lg);
+  color: var(--color-neutral);
+  font-size: var(--text-sm);
+  line-height: 1.55;
+}
+
+.ad-recovery-panel__status[data-tone="error"] {
+  color: var(--color-danger);
+}
+
+.ad-recovery-panel__status[data-tone="success"] {
+  color: var(--color-success);
+}
+
+.ad-recovery-panel__status svg {
+  width: var(--space-md);
+  height: var(--space-md);
+  flex: 0 0 auto;
+  margin-top: var(--space-3xs);
+}
+
+.ad-recovery-panel__privacy {
+  padding: var(--space-sm) var(--space-lg) var(--space-lg);
+  color: var(--color-muted);
+  font-size: var(--text-xs);
+  line-height: 1.5;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ad-recovery-panel__primary:hover,
+  .ad-recovery-panel[data-ui-state="hover"] .ad-recovery-panel__primary {
+    background: var(--color-accent-hover);
+  }
+
+  .ad-recovery-panel__later:hover,
+  .ad-recovery-panel__close:hover {
+    background: var(--color-paper-2);
+  }
+}
+
+@media (min-width: 40rem) {
+  .ad-recovery-panel__actions {
+    flex-direction: row;
+  }
+
+  .ad-recovery-panel__primary {
+    flex: 1 1 auto;
+  }
+}
+
+@keyframes ad-recovery-enter {
+  from {
+    opacity: 0;
+    transform: translateY(var(--space-xs)) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes ad-recovery-backdrop {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes ad-recovery-spin {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+.ad-recovery-preview {
+  display: grid;
+  gap: var(--space-2xl);
+  min-height: 100%;
+  background: var(--color-paper-2);
+  padding: var(--space-xl);
+  color: var(--color-ink);
+  font-family: var(--font-body);
+}
+
+.ad-recovery-preview__header {
+  display: grid;
+  gap: var(--space-xs);
+}
+
+.ad-recovery-preview__header h1 {
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-style: normal;
+}
+
+.ad-recovery-preview__header p,
+.ad-recovery-preview article > span {
+  color: var(--color-muted);
+  font-size: var(--text-sm);
+}
+
+.ad-recovery-preview__variants,
+.ad-recovery-preview__states {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 24rem), 1fr));
+  gap: var(--space-xl);
+}
+
+.ad-recovery-preview article {
+  display: grid;
+  align-content: start;
+  gap: var(--space-sm);
+  min-width: 0;
+}
+
+.ad-recovery-preview .ad-recovery-panel {
+  overflow: hidden;
+  border: var(--rule-hair) solid var(--color-rule-2);
+  border-radius: var(--radius-card);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ad-recovery-dialog,
+  .ad-recovery-dialog::backdrop {
+    animation-duration: 150ms !important;
+  }
+
+  .ad-recovery-dialog {
+    animation-name: ad-recovery-backdrop;
+    transform: none;
+  }
+
+  .ad-recovery-panel__spinner {
+    animation-duration: 1.2s !important;
+    animation-iteration-count: infinite !important;
+  }
+}
+
 /* Product chrome: compact ------------------------------------------------- */
 
 .site-header[data-announcement-collapsed="true"] .site-announcement {

--- a/frontend/src/components/RootDocumentExtras.tsx
+++ b/frontend/src/components/RootDocumentExtras.tsx
@@ -1,5 +1,7 @@
 import { Analytics } from "@vercel/analytics/next";
 import Script from "next/script";
+import { Suspense } from "react";
+import { AdBlockRecoveryPrompt } from "@/components/ads/AdBlockRecoveryPrompt";
 import { AdSenseScript } from "@/components/ads/AdSenseScript";
 import { AmplitudeLoader } from "@/components/AmplitudeLoader";
 import { GoogleAnalytics } from "@/components/GoogleAnalytics";
@@ -13,6 +15,9 @@ export function RootDocumentExtras() {
       <WebVitalsReporter />
       <GoogleAnalytics />
       <AdSenseScript />
+      <Suspense fallback={null}>
+        <AdBlockRecoveryPrompt />
+      </Suspense>
       {process.env.NEXT_PUBLIC_SENTRY_DSN && (
         <Script
           src={`https://js.sentry-cdn.com/${process.env.NEXT_PUBLIC_SENTRY_DSN.match(/\/\/(.+?)@/)?.[1]}.min.js`}

--- a/frontend/src/components/ads/AdBlockRecoveryPrompt.preview.tsx
+++ b/frontend/src/components/ads/AdBlockRecoveryPrompt.preview.tsx
@@ -1,0 +1,46 @@
+import {
+  AdBlockRecoveryPromptPanel,
+  type AdBlockRecoveryUiState,
+} from "@/components/ads/AdBlockRecoveryPrompt";
+
+const STATES: AdBlockRecoveryUiState[] = [
+  "default",
+  "hover",
+  "focus",
+  "active",
+  "disabled",
+  "loading",
+  "error",
+  "success",
+];
+
+export function AdBlockRecoveryPromptPreview() {
+  return (
+    <main className="ad-recovery-preview">
+      <header className="ad-recovery-preview__header">
+        <h1>Ad block recovery prompt</h1>
+        <p>A/B copy and all eight interaction states. This wrapper is not mounted in production.</p>
+      </header>
+
+      <section className="ad-recovery-preview__variants" aria-label="A/B variants">
+        <article>
+          <span>Variant A · context</span>
+          <AdBlockRecoveryPromptPanel variant="context" locale="ko" preview />
+        </article>
+        <article>
+          <span>Variant B · direct</span>
+          <AdBlockRecoveryPromptPanel variant="direct" locale="ko" preview />
+        </article>
+      </section>
+
+      <section className="ad-recovery-preview__states" aria-label="Interaction states">
+        {STATES.map((state) => (
+          <article key={state}>
+            <span>{state}</span>
+            <AdBlockRecoveryPromptPanel variant="context" locale="ko" uiState={state} preview />
+          </article>
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/components/ads/AdBlockRecoveryPrompt.tsx
+++ b/frontend/src/components/ads/AdBlockRecoveryPrompt.tsx
@@ -1,0 +1,565 @@
+"use client";
+
+import { AlertTriangle, Check, HeartHandshake, Loader2, RefreshCw, X } from "lucide-react";
+import { usePathname } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  AD_BLOCK_RECOVERY_MODE,
+  ADSENSE_CLIENT,
+  ADSENSE_PREVIEW,
+} from "@/components/ads/adsenseConfig";
+import { canLoadAds } from "@/components/ads/AdSenseScript";
+import type { RouteLocale } from "@/i18n/routing";
+import {
+  consumeRecentAdBlockRecoveryAttempt,
+  getRandomExperimentBucket,
+  isAdBlockRecoveryPromptSuppressed,
+  markAdBlockRecoveryAttempt,
+  resolveAdBlockRecoveryVariant,
+  suppressAdBlockRecoveryPrompt,
+  type AdBlockRecoveryDismissReason,
+  type AdBlockRecoveryVariant,
+  type StorageLike,
+} from "@/lib/adBlockRecoveryExperiment";
+import { analytics } from "@/lib/analytics";
+
+const DETECTION_DELAY_MS = 6000;
+
+const memoryStorageValues = new Map<string, string>();
+const memoryStorage: StorageLike = {
+  getItem: (key) => memoryStorageValues.get(key) ?? null,
+  setItem: (key, value) => memoryStorageValues.set(key, value),
+  removeItem: (key) => memoryStorageValues.delete(key),
+};
+
+export type AdBlockRecoveryUiState =
+  | "default"
+  | "hover"
+  | "focus"
+  | "active"
+  | "disabled"
+  | "loading"
+  | "error"
+  | "success";
+
+interface PromptCopy {
+  title: string;
+  body: string;
+  instruction: string;
+  primary: string;
+  later: string;
+  close: string;
+  loading: string;
+  error: string;
+  success: string;
+  privacy: string;
+}
+
+const COPY: Record<RouteLocale, Record<AdBlockRecoveryVariant, PromptCopy>> = {
+  ko: {
+    context: {
+      title: "잠깐, 작은 부탁 하나만 드릴게요",
+      body: "ER&GG를 운영하려면 서버비와 데이터 유지 비용이 들어요. 광고를 허용해 주시면 지금처럼 무료로 계속 제공하는 데 큰 도움이 됩니다.",
+      instruction: "괜찮으시다면 광고 차단기에서 ER&GG만 허용해 주신 뒤 새로고침해 주세요.",
+      primary: "광고 허용하고 새로고침",
+      later: "다음에 도울게요",
+      close: "광고 안내 닫기",
+      loading: "확인하는 중…",
+      error: "새로고침이 되지 않았어요. 번거롭겠지만 브라우저에서 한 번만 직접 새로고침해 주세요.",
+      success: "고맙습니다. 광고 허용을 확인했어요.",
+      privacy: "광고 차단 여부만 브라우저에서 확인합니다. 차단기 설정은 보거나 저장하지 않아요.",
+    },
+    direct: {
+      title: "ER&GG에서 광고를 허용해 주세요",
+      body: "광고 수익은 서버와 데이터 운영에 사용됩니다.",
+      instruction: "광고 차단기에서 이 사이트를 허용한 뒤 새로고침해 주세요.",
+      primary: "허용했어요 · 새로고침",
+      later: "광고 차단 유지",
+      close: "광고 안내 닫기",
+      loading: "확인하는 중…",
+      error: "새로고침이 되지 않았어요. 번거롭겠지만 브라우저에서 한 번만 직접 새로고침해 주세요.",
+      success: "고맙습니다. 광고 허용을 확인했어요.",
+      privacy: "광고 차단 여부만 브라우저에서 확인합니다. 차단기 설정은 보거나 저장하지 않아요.",
+    },
+  },
+  en: {
+    context: {
+      title: "Could we ask a small favor?",
+      body: "ER&GG has server and data costs behind it. Allowing ads helps us keep everything free to use.",
+      instruction: "If you don’t mind, allow ads just for ER&GG in your blocker, then refresh.",
+      primary: "Allow ads and refresh",
+      later: "Maybe next time",
+      close: "Close ad notice",
+      loading: "Checking…",
+      error: "The page did not refresh. Please refresh it once from your browser.",
+      success: "Thank you — ads are now allowed.",
+      privacy:
+        "We only check whether ads are blocked in your browser. We never view or save your blocker settings.",
+    },
+    direct: {
+      title: "Allow ads on ER&GG",
+      body: "Ad revenue keeps our servers and data running.",
+      instruction: "Allow this site in your ad blocker, then refresh.",
+      primary: "Allowed · Refresh",
+      later: "Keep blocking",
+      close: "Close ad notice",
+      loading: "Checking…",
+      error: "The page did not refresh. Please refresh it once from your browser.",
+      success: "Thank you — ads are now allowed.",
+      privacy:
+        "We only check whether ads are blocked in your browser. We never view or save your blocker settings.",
+    },
+  },
+  ja: {
+    context: {
+      title: "少しだけ、お願いがあります",
+      body: "ER&GGの運営には、サーバーやデータ維持の費用がかかります。広告を許可していただけると、これからも無料で続ける大きな支えになります。",
+      instruction: "よろしければ、広告ブロッカーでER&GGだけを許可してから再読み込みしてください。",
+      primary: "協力して再読み込み",
+      later: "また今度",
+      close: "広告の案内を閉じる",
+      loading: "確認中…",
+      error:
+        "再読み込みできませんでした。お手数ですが、ブラウザから一度だけ再読み込みしてください。",
+      success: "ありがとうございます。広告の許可を確認しました。",
+      privacy:
+        "広告がブロックされているかだけをブラウザで確認します。ブロッカーの設定を見たり保存したりはしません。",
+    },
+    direct: {
+      title: "ER&GGの広告を許可してください",
+      body: "広告収益はサーバーとデータ運営に使われます。",
+      instruction: "広告ブロッカーでこのサイトを許可して、再読み込みしてください。",
+      primary: "許可した · 再読み込み",
+      later: "ブロックを続ける",
+      close: "広告の案内を閉じる",
+      loading: "確認中…",
+      error:
+        "再読み込みできませんでした。お手数ですが、ブラウザから一度だけ再読み込みしてください。",
+      success: "ありがとうございます。広告の許可を確認しました。",
+      privacy:
+        "広告がブロックされているかだけをブラウザで確認します。ブロッカーの設定を見たり保存したりはしません。",
+    },
+  },
+  "zh-Hans": {
+    context: {
+      title: "想拜托你一件小事",
+      body: "ER&GG 的服务器和数据维护都需要成本。允许广告，就能帮我们继续免费提供这些内容。",
+      instruction: "如果你愿意，请在广告拦截器中只允许 ER&GG，然后刷新页面。",
+      primary: "允许广告并刷新",
+      later: "下次再说",
+      close: "关闭广告提示",
+      loading: "正在检查…",
+      error: "页面没能刷新。麻烦你在浏览器中手动刷新一次。",
+      success: "谢谢，已确认允许广告。",
+      privacy: "我们只会在浏览器中检查广告是否被拦截，不会查看或保存你的拦截器设置。",
+    },
+    direct: {
+      title: "请允许 ER&GG 显示广告",
+      body: "广告收入用于服务器和数据运营。",
+      instruction: "请在广告拦截器中允许此网站，然后刷新页面。",
+      primary: "已允许 · 刷新",
+      later: "继续拦截",
+      close: "关闭广告提示",
+      loading: "正在检查…",
+      error: "页面没能刷新。麻烦你在浏览器中手动刷新一次。",
+      success: "谢谢，已确认允许广告。",
+      privacy: "我们只会在浏览器中检查广告是否被拦截，不会查看或保存你的拦截器设置。",
+    },
+  },
+  "zh-Hant": {
+    context: {
+      title: "想拜託你一件小事",
+      body: "ER&GG 的伺服器和資料維護都需要成本。允許廣告，就能幫助我們繼續免費提供這些內容。",
+      instruction: "如果你願意，請在廣告攔截器中只允許 ER&GG，然後重新整理頁面。",
+      primary: "允許廣告並重新整理",
+      later: "下次再說",
+      close: "關閉廣告提示",
+      loading: "正在檢查…",
+      error: "頁面沒能重新整理。麻煩你在瀏覽器中手動重新整理一次。",
+      success: "謝謝，已確認允許廣告。",
+      privacy: "我們只會在瀏覽器中檢查廣告是否被攔截，不會查看或儲存你的攔截器設定。",
+    },
+    direct: {
+      title: "請允許 ER&GG 顯示廣告",
+      body: "廣告收入用於伺服器和資料營運。",
+      instruction: "請在廣告攔截器中允許此網站，然後重新整理頁面。",
+      primary: "已允許 · 重新整理",
+      later: "繼續攔截",
+      close: "關閉廣告提示",
+      loading: "正在檢查…",
+      error: "頁面沒能重新整理。麻煩你在瀏覽器中手動重新整理一次。",
+      success: "謝謝，已確認允許廣告。",
+      privacy: "我們只會在瀏覽器中檢查廣告是否被攔截，不會查看或儲存你的攔截器設定。",
+    },
+  },
+};
+
+const SUCCESS_ACTION: Record<RouteLocale, string> = {
+  ko: "확인 완료",
+  en: "Ads allowed",
+  ja: "確認しました",
+  "zh-Hans": "已确认",
+  "zh-Hant": "已確認",
+};
+
+function resolveLocale(pathname: string): RouteLocale {
+  const routeLocale = pathname.split("/")[1];
+  if (
+    routeLocale === "en" ||
+    routeLocale === "ja" ||
+    routeLocale === "zh-Hans" ||
+    routeLocale === "zh-Hant"
+  ) {
+    return routeLocale;
+  }
+  return "ko";
+}
+
+function resolvePreviewVariant(pathname: string, search: string): AdBlockRecoveryVariant | null {
+  if (!pathname.includes("/design-lab")) return null;
+  const previewVariant = new URLSearchParams(search).get("adblock-recovery-preview");
+  return previewVariant === "context" || previewVariant === "direct" ? previewVariant : null;
+}
+
+function isBaitHidden(element: HTMLDivElement): boolean {
+  const style = window.getComputedStyle(element);
+  const rect = element.getBoundingClientRect();
+  return (
+    style.display === "none" ||
+    style.visibility === "hidden" ||
+    rect.width === 0 ||
+    rect.height === 0
+  );
+}
+
+function getClientStorage(): StorageLike {
+  try {
+    return window.localStorage;
+  } catch {
+    return memoryStorage;
+  }
+}
+
+interface AdBlockRecoveryPromptPanelProps {
+  variant: AdBlockRecoveryVariant;
+  locale: RouteLocale;
+  uiState?: AdBlockRecoveryUiState;
+  onReload?: () => void;
+  onDismiss?: () => void;
+  onClose?: () => void;
+  primaryButtonRef?: React.RefObject<HTMLButtonElement | null>;
+  preview?: boolean;
+}
+
+export function AdBlockRecoveryPromptPanel({
+  variant,
+  locale,
+  uiState = "default",
+  onReload,
+  onDismiss,
+  onClose,
+  primaryButtonRef,
+  preview = false,
+}: AdBlockRecoveryPromptPanelProps) {
+  const copy = COPY[locale]?.[variant] ?? COPY.ko[variant];
+  const isLoading = uiState === "loading";
+  const isDisabled = uiState === "disabled" || isLoading || uiState === "success";
+  const statusMessage =
+    uiState === "error" ? copy.error : uiState === "success" ? copy.success : null;
+
+  return (
+    <section
+      className="ad-recovery-panel"
+      data-variant={variant}
+      data-ui-state={uiState}
+      data-preview={preview ? "true" : undefined}
+      aria-labelledby={preview ? undefined : "ad-recovery-title"}
+      aria-describedby={preview ? undefined : "ad-recovery-description"}
+    >
+      <header className="ad-recovery-panel__header">
+        <span className="ad-recovery-panel__signal" aria-hidden="true">
+          <HeartHandshake />
+        </span>
+        <button
+          type="button"
+          className="ad-recovery-panel__close"
+          onClick={onClose}
+          aria-label={copy.close}
+          disabled={isLoading}
+        >
+          <X aria-hidden="true" />
+        </button>
+      </header>
+
+      <div className="ad-recovery-panel__copy">
+        <h2 id={preview ? undefined : "ad-recovery-title"}>{copy.title}</h2>
+        <p id={preview ? undefined : "ad-recovery-description"}>{copy.body}</p>
+      </div>
+
+      <div className="ad-recovery-panel__instruction">
+        <span aria-hidden="true">1</span>
+        <p>{copy.instruction}</p>
+      </div>
+
+      <div className="ad-recovery-panel__actions">
+        <button
+          ref={primaryButtonRef}
+          type="button"
+          className="ad-recovery-panel__primary"
+          onClick={onReload}
+          disabled={isDisabled}
+          aria-busy={isLoading}
+        >
+          {isLoading ? (
+            <Loader2 className="ad-recovery-panel__spinner" aria-hidden="true" />
+          ) : uiState === "success" ? (
+            <Check aria-hidden="true" />
+          ) : uiState === "error" ? (
+            <AlertTriangle aria-hidden="true" />
+          ) : (
+            <RefreshCw aria-hidden="true" />
+          )}
+          <span>
+            {isLoading
+              ? copy.loading
+              : uiState === "success"
+                ? SUCCESS_ACTION[locale]
+                : copy.primary}
+          </span>
+        </button>
+        <button
+          type="button"
+          className="ad-recovery-panel__later"
+          onClick={onDismiss}
+          disabled={isLoading}
+        >
+          {copy.later}
+        </button>
+      </div>
+
+      <div
+        className="ad-recovery-panel__status"
+        data-tone={uiState === "error" ? "error" : uiState === "success" ? "success" : undefined}
+        role={uiState === "error" ? "alert" : "status"}
+        aria-live="polite"
+      >
+        {statusMessage ? (
+          <>
+            {uiState === "error" ? (
+              <AlertTriangle aria-hidden="true" />
+            ) : (
+              <Check aria-hidden="true" />
+            )}
+            <span>{statusMessage}</span>
+          </>
+        ) : null}
+      </div>
+
+      <p className="ad-recovery-panel__privacy">{copy.privacy}</p>
+    </section>
+  );
+}
+
+export function AdBlockRecoveryPrompt() {
+  const pathname = usePathname();
+  const baitRef = useRef<HTMLDivElement | null>(null);
+  const dialogRef = useRef<HTMLDialogElement | null>(null);
+  const primaryButtonRef = useRef<HTMLButtonElement | null>(null);
+  const shownPathRef = useRef<string | null>(null);
+  const dismissInProgressRef = useRef(false);
+  const [variant, setVariant] = useState<AdBlockRecoveryVariant>("context");
+  const [isOpen, setIsOpen] = useState(false);
+  const [isPreviewMode, setIsPreviewMode] = useState(false);
+  const [uiState, setUiState] = useState<AdBlockRecoveryUiState>("default");
+  const locale = resolveLocale(pathname);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const dialog = dialogRef.current;
+    if (!dialog || dialog.open) return;
+    dialog.showModal();
+    requestAnimationFrame(() => primaryButtonRef.current?.focus());
+  }, [isOpen]);
+
+  useEffect(() => {
+    const previewVariant = resolvePreviewVariant(pathname, window.location.search);
+    if (previewVariant) {
+      const previewTimer = window.setTimeout(() => {
+        setVariant(previewVariant);
+        setIsPreviewMode(true);
+        setUiState("default");
+        dismissInProgressRef.current = false;
+        setIsOpen(true);
+      }, 0);
+      return () => window.clearTimeout(previewTimer);
+    }
+
+    if (
+      AD_BLOCK_RECOVERY_MODE === "off" ||
+      !ADSENSE_CLIENT ||
+      ADSENSE_PREVIEW ||
+      !canLoadAds(pathname)
+    ) {
+      return;
+    }
+    const storage = getClientStorage();
+    if (isAdBlockRecoveryPromptSuppressed(storage, Date.now())) return;
+
+    let timerId: ReturnType<typeof setTimeout> | null = null;
+
+    const runDetection = () => {
+      if (document.visibilityState !== "visible" || navigator.onLine === false) return;
+      const bait = baitRef.current;
+      if (!bait) return;
+
+      const blocked = isBaitHidden(bait);
+      if (!blocked) {
+        const attempt = consumeRecentAdBlockRecoveryAttempt(storage, Date.now());
+        if (attempt) {
+          analytics.adBlockRecoverySucceeded({
+            variant: attempt.variant,
+            attemptAgeMs: Date.now() - attempt.attemptedAt,
+            attemptPagePath: attempt.pagePath,
+            pagePath: pathname,
+          });
+        }
+        return;
+      }
+
+      if (shownPathRef.current === pathname) return;
+      const assignedVariant = resolveAdBlockRecoveryVariant(
+        storage,
+        AD_BLOCK_RECOVERY_MODE,
+        getRandomExperimentBucket()
+      );
+      if (!assignedVariant) return;
+      shownPathRef.current = pathname;
+      setVariant(assignedVariant);
+      setUiState("default");
+      dismissInProgressRef.current = false;
+      setIsOpen(true);
+      analytics.adBlockRecoveryPromptShown({
+        variant: assignedVariant,
+        locale,
+        pagePath: pathname,
+        detectionMethod: "cosmetic_bait",
+      });
+    };
+
+    const scheduleDetection = () => {
+      if (timerId) clearTimeout(timerId);
+      if (document.visibilityState !== "visible" || navigator.onLine === false) return;
+      timerId = setTimeout(runDetection, DETECTION_DELAY_MS);
+    };
+
+    const handleVisibilityChange = () => scheduleDetection();
+    const handleOnline = () => scheduleDetection();
+
+    scheduleDetection();
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("online", handleOnline);
+
+    return () => {
+      if (timerId) clearTimeout(timerId);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("online", handleOnline);
+    };
+  }, [locale, pathname]);
+
+  const dismiss = useCallback(
+    (reason: AdBlockRecoveryDismissReason) => {
+      if (dismissInProgressRef.current) return;
+      dismissInProgressRef.current = true;
+
+      if (!isPreviewMode) {
+        suppressAdBlockRecoveryPrompt(getClientStorage(), Date.now());
+        analytics.adBlockRecoveryPromptDismissed({
+          variant,
+          reason,
+          locale,
+          pagePath: pathname,
+        });
+      }
+      setIsOpen(false);
+      setUiState("default");
+    },
+    [isPreviewMode, locale, pathname, variant]
+  );
+
+  const handleReload = useCallback(() => {
+    if (isPreviewMode) {
+      setUiState("loading");
+      window.setTimeout(() => setUiState("success"), 500);
+      return;
+    }
+
+    const now = Date.now();
+    markAdBlockRecoveryAttempt(getClientStorage(), {
+      variant,
+      attemptedAt: now,
+      pagePath: pathname,
+    });
+    analytics.adBlockRecoveryReloadRequested({
+      variant,
+      locale,
+      pagePath: pathname,
+    });
+    setUiState("loading");
+
+    window.setTimeout(() => {
+      try {
+        window.location.reload();
+      } catch {
+        setUiState("error");
+      }
+    }, 120);
+  }, [isPreviewMode, locale, pathname, variant]);
+
+  return (
+    <>
+      <div
+        ref={baitRef}
+        className="adsbox ad-banner ad-unit advertisement"
+        aria-hidden="true"
+        style={{
+          position: "fixed",
+          insetInlineStart: "-10000px",
+          top: "-10000px",
+          width: "1px",
+          height: "1px",
+          pointerEvents: "none",
+        }}
+      />
+
+      {isOpen ? (
+        <dialog
+          ref={dialogRef}
+          className="ad-recovery-dialog"
+          aria-label={COPY[locale][variant].title}
+          onCancel={(event) => {
+            event.preventDefault();
+            dismiss("escape");
+          }}
+          onKeyDown={(event) => {
+            if (event.key !== "Escape") return;
+            event.preventDefault();
+            dismiss("escape");
+          }}
+          onClick={(event) => {
+            if (event.target === event.currentTarget) dismiss("backdrop");
+          }}
+        >
+          <AdBlockRecoveryPromptPanel
+            variant={variant}
+            locale={locale}
+            uiState={uiState}
+            onReload={handleReload}
+            onDismiss={() => dismiss("later")}
+            onClose={() => dismiss("close")}
+            primaryButtonRef={primaryButtonRef}
+          />
+        </dialog>
+      ) : null}
+    </>
+  );
+}

--- a/frontend/src/components/ads/AdSenseScript.tsx
+++ b/frontend/src/components/ads/AdSenseScript.tsx
@@ -18,7 +18,7 @@ function stripLocale(pathname: string) {
   return pathname.replace(/^\/(?:ko|en|ja)(?=\/|$)/, "") || "/";
 }
 
-function canLoadAds(pathname: string) {
+export function canLoadAds(pathname: string) {
   const normalized = stripLocale(pathname);
   if (normalized.includes("/preview")) return false;
   if (normalized === "/") return true;

--- a/frontend/src/components/ads/adsenseConfig.ts
+++ b/frontend/src/components/ads/adsenseConfig.ts
@@ -1,3 +1,5 @@
+import type { AdBlockRecoveryMode } from "@/lib/adBlockRecoveryExperiment";
+
 const DEFAULT_ADSENSE_CLIENT = "ca-pub-4008956736614349";
 const DEFAULT_DISPLAY_SLOT = "8139813658";
 const ADSENSE_DISABLED = process.env.NEXT_PUBLIC_ADSENSE_DISABLED === "true";
@@ -10,6 +12,23 @@ export const ADSENSE_CLIENT = ADSENSE_DISABLED
 
 export const ADSENSE_PREVIEW =
   !ADSENSE_DISABLED && process.env.NEXT_PUBLIC_ADSENSE_PREVIEW === "true";
+
+function resolveAdBlockRecoveryMode(): AdBlockRecoveryMode {
+  const configured = process.env.NEXT_PUBLIC_AD_BLOCK_RECOVERY_MODE;
+  if (
+    configured === "off" ||
+    configured === "experiment" ||
+    configured === "context" ||
+    configured === "direct"
+  ) {
+    return configured;
+  }
+
+  if (configured) return "off";
+  return process.env.NODE_ENV === "production" ? "experiment" : "off";
+}
+
+export const AD_BLOCK_RECOVERY_MODE = resolveAdBlockRecoveryMode();
 
 export interface AdSlotReservation {
   baseHeight: number;

--- a/frontend/src/lib/adBlockRecoveryExperiment.ts
+++ b/frontend/src/lib/adBlockRecoveryExperiment.ts
@@ -1,0 +1,133 @@
+export const AD_BLOCK_RECOVERY_EXPERIMENT = "adblock_recovery_prompt_v1";
+
+export type AdBlockRecoveryVariant = "context" | "direct";
+export type AdBlockRecoveryMode = "off" | "experiment" | AdBlockRecoveryVariant;
+export type AdBlockRecoveryDismissReason = "close" | "later" | "backdrop" | "escape";
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+export interface RecoveryAttempt {
+  variant: AdBlockRecoveryVariant;
+  attemptedAt: number;
+  pagePath: string;
+}
+
+const STORAGE_KEYS = {
+  variant: "ergg:adblock-recovery:v1:variant",
+  dismissedUntil: "ergg:adblock-recovery:v1:dismissed-until",
+  recoveryAttempt: "ergg:adblock-recovery:v1:attempt",
+} as const;
+
+export const DISMISS_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+export const RECOVERY_ATTEMPT_TTL_MS = 30 * 60 * 1000;
+
+function isVariant(value: unknown): value is AdBlockRecoveryVariant {
+  return value === "context" || value === "direct";
+}
+
+export function getOrCreateAdBlockRecoveryVariant(
+  storage: StorageLike,
+  randomBucket: number
+): AdBlockRecoveryVariant {
+  try {
+    const stored = storage.getItem(STORAGE_KEYS.variant);
+    if (isVariant(stored)) return stored;
+  } catch {
+    // Storage can be unavailable in private or restricted browsing contexts.
+  }
+
+  const variant: AdBlockRecoveryVariant = randomBucket < 0.5 ? "context" : "direct";
+
+  try {
+    storage.setItem(STORAGE_KEYS.variant, variant);
+  } catch {
+    // The in-memory assignment still keeps this render internally consistent.
+  }
+
+  return variant;
+}
+
+export function resolveAdBlockRecoveryVariant(
+  storage: StorageLike,
+  mode: AdBlockRecoveryMode,
+  randomBucket: number
+): AdBlockRecoveryVariant | null {
+  if (mode === "off") return null;
+  if (mode === "context" || mode === "direct") return mode;
+  return getOrCreateAdBlockRecoveryVariant(storage, randomBucket);
+}
+
+export function isAdBlockRecoveryPromptSuppressed(storage: StorageLike, now: number): boolean {
+  try {
+    const dismissedUntil = Number(storage.getItem(STORAGE_KEYS.dismissedUntil));
+    return Number.isFinite(dismissedUntil) && dismissedUntil > now;
+  } catch {
+    return false;
+  }
+}
+
+export function suppressAdBlockRecoveryPrompt(storage: StorageLike, now: number): void {
+  try {
+    storage.setItem(STORAGE_KEYS.dismissedUntil, String(now + DISMISS_COOLDOWN_MS));
+  } catch {
+    // The prompt remains dismissible for the current render even without storage.
+  }
+}
+
+export function markAdBlockRecoveryAttempt(storage: StorageLike, attempt: RecoveryAttempt): void {
+  try {
+    storage.setItem(STORAGE_KEYS.recoveryAttempt, JSON.stringify(attempt));
+  } catch {
+    // Analytics conversion will be unavailable, but reload must still proceed.
+  }
+}
+
+export function consumeRecentAdBlockRecoveryAttempt(
+  storage: StorageLike,
+  now: number
+): RecoveryAttempt | null {
+  let raw: string | null = null;
+
+  try {
+    raw = storage.getItem(STORAGE_KEYS.recoveryAttempt);
+    storage.removeItem(STORAGE_KEYS.recoveryAttempt);
+  } catch {
+    return null;
+  }
+
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<RecoveryAttempt>;
+    if (!isVariant(parsed.variant)) return null;
+    if (typeof parsed.attemptedAt !== "number" || !Number.isFinite(parsed.attemptedAt)) {
+      return null;
+    }
+    if (typeof parsed.pagePath !== "string") return null;
+    if (now - parsed.attemptedAt < 0 || now - parsed.attemptedAt > RECOVERY_ATTEMPT_TTL_MS) {
+      return null;
+    }
+
+    return {
+      variant: parsed.variant,
+      attemptedAt: parsed.attemptedAt,
+      pagePath: parsed.pagePath,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function getRandomExperimentBucket(): number {
+  if (typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function") {
+    const value = new Uint32Array(1);
+    crypto.getRandomValues(value);
+    return value[0] / 2 ** 32;
+  }
+
+  return Math.random();
+}

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -1,3 +1,9 @@
+import {
+  AD_BLOCK_RECOVERY_EXPERIMENT,
+  type AdBlockRecoveryDismissReason,
+  type AdBlockRecoveryVariant,
+} from "@/lib/adBlockRecoveryExperiment";
+
 type AmplitudeModule = typeof import("@amplitude/analytics-browser");
 
 const isDev = process.env.NODE_ENV === "development";
@@ -16,6 +22,17 @@ function track(event: string, properties?: Record<string, unknown>) {
   if (isDev) return;
   getAmplitude()
     .then((amplitude) => amplitude.track(event, properties))
+    .catch(() => {});
+}
+
+type FlatAnalyticsProperties = Record<string, string | number | boolean | null | undefined>;
+
+function trackAdBlockRecovery(event: string, properties: FlatAnalyticsProperties) {
+  track(event, properties);
+  if (isDev) return;
+
+  import("@vercel/analytics")
+    .then((vercelAnalytics) => vercelAnalytics.track(event, properties))
     .catch(() => {});
 }
 
@@ -350,6 +367,68 @@ export const analytics = {
       page_path: getCurrentPagePath(),
       reserved_height: args.reservedHeight,
       reserved_width: args.reservedWidth,
+    });
+  },
+
+  /** 광고 차단 해제 팝업 실험 노출 — 감지된 세션에서 실제 dialog가 열린 경우만 기록한다. */
+  adBlockRecoveryPromptShown(args: {
+    variant: AdBlockRecoveryVariant;
+    locale: string;
+    pagePath: string;
+    detectionMethod: "cosmetic_bait";
+  }) {
+    trackAdBlockRecovery("ad_block_recovery_prompt_shown", {
+      experiment: AD_BLOCK_RECOVERY_EXPERIMENT,
+      variant: args.variant,
+      locale: args.locale,
+      page_path: args.pagePath,
+      detection_method: args.detectionMethod,
+    });
+  },
+
+  /** 명시적 닫기, 나중에, backdrop, Escape를 구분해 팝업 거부율을 측정한다. */
+  adBlockRecoveryPromptDismissed(args: {
+    variant: AdBlockRecoveryVariant;
+    reason: AdBlockRecoveryDismissReason;
+    locale: string;
+    pagePath: string;
+  }) {
+    trackAdBlockRecovery("ad_block_recovery_prompt_dismissed", {
+      experiment: AD_BLOCK_RECOVERY_EXPERIMENT,
+      variant: args.variant,
+      reason: args.reason,
+      locale: args.locale,
+      page_path: args.pagePath,
+    });
+  },
+
+  /** 사용자가 광고 허용 후 확인을 위해 새로고침을 선택한 경우. */
+  adBlockRecoveryReloadRequested(args: {
+    variant: AdBlockRecoveryVariant;
+    locale: string;
+    pagePath: string;
+  }) {
+    trackAdBlockRecovery("ad_block_recovery_reload_requested", {
+      experiment: AD_BLOCK_RECOVERY_EXPERIMENT,
+      variant: args.variant,
+      locale: args.locale,
+      page_path: args.pagePath,
+    });
+  },
+
+  /** 새로고침 뒤 광고 차단 bait가 정상 노출되어 해제 성공으로 확인된 경우. */
+  adBlockRecoverySucceeded(args: {
+    variant: AdBlockRecoveryVariant;
+    attemptAgeMs: number;
+    attemptPagePath: string;
+    pagePath: string;
+  }) {
+    trackAdBlockRecovery("ad_block_recovery_succeeded", {
+      experiment: AD_BLOCK_RECOVERY_EXPERIMENT,
+      variant: args.variant,
+      attempt_age_ms: args.attemptAgeMs,
+      attempt_page_path: args.attemptPagePath,
+      page_path: args.pagePath,
     });
   },
 


### PR DESCRIPTION
## Summary

- 광고 차단을 감지한 사용자에게만 해제 요청 팝업을 노출합니다.
- `context`와 `direct` 문구를 50:50으로 고정 배정하고, 24시간 재노출 제한과 `off | experiment | context | direct` 운영 모드를 지원합니다.
- 노출·닫기·새로고침 요청·해제 성공 이벤트를 Amplitude와 Vercel Analytics에 기록합니다.
- 한국어·영어·일본어 문구와 반응형·키보드 접근성을 적용했습니다.

## Test plan

- [x] `adBlockRecoveryExperiment.test.ts`, `analytics.test.ts` 24개 통과
- [x] 변경 파일 ESLint 및 Prettier 통과
- [x] TypeScript `tsc --noEmit` 통과
- [x] Next.js 프로덕션 빌드 통과
- [x] A/B 팝업 노출, 닫기, Escape, 새로고침 성공 상태 확인
- [x] 라이트·다크 모드와 320px·375px·414px·768px 화면에서 오버플로 및 콘솔 오류 없음 확인

Closes #225
