### PR TITLE
[fix] 광고 복구 감지 시간 및 왼쪽 레일 노출 조정

### DIFF
--- a/frontend/src/components/AppFrame.tsx
+++ b/frontend/src/components/AppFrame.tsx
@@ -56,12 +56,12 @@ export function AppFrame({
           <div
             className={
               showRailAds
-                ? "app-layout mx-auto grid w-full max-w-[1720px] grid-cols-1 gap-4 px-3 pt-4 pb-8 sm:px-4 sm:pt-5 sm:pb-10 lg:px-6 lg:pt-5 lg:pb-8 min-[1440px]:grid-cols-[160px_minmax(0,1fr)] min-[1700px]:grid-cols-[160px_minmax(0,1fr)_160px]"
+                ? "app-layout mx-auto grid w-full max-w-[1720px] grid-cols-1 gap-4 px-3 pt-4 pb-8 sm:px-4 sm:pt-5 sm:pb-10 lg:px-6 lg:pt-5 lg:pb-8 min-[1280px]:grid-cols-[160px_minmax(0,1fr)] min-[1700px]:grid-cols-[160px_minmax(0,1fr)_160px]"
                 : "app-layout mx-auto w-full max-w-[1440px] px-3 pt-4 pb-8 sm:px-4 sm:pt-5 sm:pb-10 lg:px-6 lg:pt-5 lg:pb-8"
             }
           >
             {showRailAds ? (
-              <aside className="hidden min-[1440px]:block" aria-label="Left advertisement">
+              <aside className="hidden min-[1280px]:block" aria-label="Left advertisement">
                 {showLeftRailAd ? (
                   <div className="sticky top-[5.5rem] w-full">
                     <AdSlot

--- a/frontend/src/components/ads/AdBlockRecoveryPrompt.tsx
+++ b/frontend/src/components/ads/AdBlockRecoveryPrompt.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/lib/adBlockRecoveryExperiment";
 import { analytics } from "@/lib/analytics";
 
-const DETECTION_DELAY_MS = 6000;
+const DETECTION_DELAY_MS = 3000;
 
 const memoryStorageValues = new Map<string, string>();
 const memoryStorage: StorageLike = {


### PR DESCRIPTION
## Summary

- 광고 차단 감지 대기 시간을 6초에서 3초로 줄였습니다.
- 왼쪽 광고 레일 노출 기준을 1440px에서 1280px로 낮췄습니다.
- 1280px 화면에서 160px 광고 레일을 유지하면서 본문 가로 오버플로가 발생하지 않도록 했습니다.

## Test plan

- [x] 관련 테스트 24개 통과
- [x] 변경 파일 ESLint 및 Prettier 통과
- [x] TypeScript `tsc --noEmit` 통과
- [x] Next.js 프로덕션 빌드 통과
- [x] 1280px 브라우저에서 왼쪽 레일 160px 노출 및 가로 오버플로 없음 확인

Follow-up to #226
