### PR TITLE
[fix] 캐릭터 상세 ISR 재생성 주기 롤백

### DIFF
--- a/frontend/src/app/(default)/character/[code]/page.tsx
+++ b/frontend/src/app/(default)/character/[code]/page.tsx
@@ -14,7 +14,6 @@ import { getStaticTranslator, OG_LOCALE_BY_LANGUAGE } from "@/lib/staticIntl";
 
 export const dynamic = "force-static";
 export const dynamicParams = false;
-export const revalidate = 900;
 
 interface Props {
   params: Promise<{ code: string }>;

--- a/frontend/src/app/(site)/[locale]/character/[code]/page.tsx
+++ b/frontend/src/app/(site)/[locale]/character/[code]/page.tsx
@@ -15,7 +15,6 @@ import { getStaticTranslator, OG_LOCALE_BY_LANGUAGE } from "@/lib/staticIntl";
 
 export const dynamic = "force-static";
 export const dynamicParams = false;
-export const revalidate = 900;
 
 interface Props {
   params: Promise<{ locale: string; code: string }>;

--- a/frontend/src/app/(site)/[locale]/page.tsx
+++ b/frontend/src/app/(site)/[locale]/page.tsx
@@ -15,7 +15,7 @@ import { buildLocalizedAlternates, localizeRoutePath } from "@/lib/seoLocales";
 import { BASE_URL } from "@/lib/siteMetadata";
 import { getMessage, loadIntlMessages, OG_LOCALE_BY_LANGUAGE } from "@/lib/staticIntl";
 
-export const revalidate = 900;
+export const revalidate = 3600;
 export const dynamic = "force-static";
 export const dynamicParams = false;
 

--- a/frontend/src/lib/getPatches.ts
+++ b/frontend/src/lib/getPatches.ts
@@ -10,7 +10,7 @@ import { createServerClient } from "@/lib/supabase";
 /**
  * 활성 패치 목록은 변경 빈도가 낮아서 요청 간 캐시로 묶는다.
  * 같은 프로세스 내 재요청은 Next Data Cache가 재사용하고,
- * 1시간 뒤 자동 재검증되도록 둔다.
+ * 6시간 뒤 자동 재검증되도록 둔다.
  */
 export const getPatches = unstable_cache(
   async (): Promise<string[]> => {
@@ -51,7 +51,7 @@ export const getPatches = unstable_cache(
   },
   ["patches", "patch-notes-v9-12-2-sample-gate-x8"],
   {
-    revalidate: 900,
+    revalidate: 21600,
     tags: ["patches"],
   }
 );


### PR DESCRIPTION
## Summary

- 기본·다국어 캐릭터 상세 경로에 추가된 15분 time-based ISR 재생성을 제거했습니다.
- 메인 페이지 재검증 주기를 15분에서 기존 1시간으로 복원했습니다.
- 패치 목록 데이터 캐시를 15분에서 기존 6시간으로 복원했습니다.
- 12.2 패치 전환과 표본 게이트 로직은 유지합니다.

## Test plan

- [x] 변경 파일 ESLint 및 Prettier 통과
- [x] TypeScript tsc --noEmit 통과
- [x] git diff --check 통과

Closes #230