### PR TITLE
[feat] 광고 Viewability 퍼널 및 성능 비용 계측

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 !README.md
 !**/README.md
 !frontend/docs/NEXT_RENDERING_STRATEGY_AUDIT_2026-07-20.md
+!pm/ad-monetization-performance-measurement.md
 
 # Backend
 backend/dist/

--- a/frontend/src/__tests__/adPerformance.test.ts
+++ b/frontend/src/__tests__/adPerformance.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { getResourceHost, isAdResourceUrl } from "@/lib/adPerformance";
+
+describe("adPerformance resource classification", () => {
+  it.each([
+    "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js",
+    "https://googleads.g.doubleclick.net/pagead/ads?client=test",
+    "https://tpc.googlesyndication.com/sodar/sodar.bin",
+  ])("광고 공급 도메인을 분류한다: %s", (url) => {
+    expect(isAdResourceUrl(url)).toBe(true);
+  });
+
+  it.each([
+    "https://erwagg.com/_next/static/chunks/app.js",
+    "https://www.googletagmanager.com/gtag/js?id=G-test",
+    "https://api2.amplitude.com/2/httpapi",
+  ])("분석/자사 리소스를 광고 비용으로 오분류하지 않는다: %s", (url) => {
+    expect(isAdResourceUrl(url)).toBe(false);
+  });
+
+  it("전체 URL 대신 낮은 cardinality의 host만 반환한다", () => {
+    expect(getResourceHost("https://www.googleads.g.doubleclick.net/pagead/ads?a=1")).toBe(
+      "googleads.g.doubleclick.net"
+    );
+  });
+});

--- a/frontend/src/__tests__/adSenseScript.test.ts
+++ b/frontend/src/__tests__/adSenseScript.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { canLoadAds } from "@/components/ads/AdSenseScript";
+
+describe("AdSenseScript route eligibility", () => {
+  it.each([
+    "/ko",
+    "/en/character/1",
+    "/ja/synergy-detail",
+    "/zh-Hans/patches/12.2",
+    "/zh-Hant/patch-analysis/12.2",
+  ])("지원 locale의 콘텐츠 경로에서 광고를 허용한다: %s", (pathname) => {
+    expect(canLoadAds(pathname)).toBe(true);
+  });
+
+  it.each(["/ko/privacy", "/zh-Hans/terms", "/ja/patches/preview"])(
+    "제외 경로에서는 광고를 로드하지 않는다: %s",
+    (pathname) => {
+      expect(canLoadAds(pathname)).toBe(false);
+    }
+  );
+});

--- a/frontend/src/__tests__/analytics.test.ts
+++ b/frontend/src/__tests__/analytics.test.ts
@@ -322,13 +322,17 @@ describe("analytics — P0 helpers", () => {
         pagePath: "/ko/synergy-detail",
       });
       await flushAsync();
-      expect(trackMock).toHaveBeenCalledWith("ad_slot_rendered", {
-        slot_name: "synergy_detail_top",
-        ad_slot_id: "8139813658",
-        page_path: "/ko/synergy-detail",
-        reserved_height: undefined,
-        reserved_width: undefined,
-      });
+      expect(trackMock).toHaveBeenCalledWith(
+        "ad_slot_rendered",
+        expect.objectContaining({
+          slot_name: "synergy_detail_top",
+          ad_slot_id: "8139813658",
+          page_path: "/ko/synergy-detail",
+          page_surface: "synergy_detail",
+          ad_delivery_state: "no_slot",
+          ad_resource_count: 0,
+        })
+      );
     });
 
     it("ad_slot_viewed 에 슬롯명과 viewport 정보를 전달한다", async () => {
@@ -341,15 +345,18 @@ describe("analytics — P0 helpers", () => {
         pagePath: "/ko",
       });
       await flushAsync();
-      expect(trackMock).toHaveBeenCalledWith("ad_slot_viewed", {
-        slot_name: "home_ranking",
-        ad_slot_id: "8139813658",
-        page_path: "/ko",
-        viewport_width: 390,
-        viewport_height: 844,
-        reserved_height: undefined,
-        reserved_width: undefined,
-      });
+      expect(trackMock).toHaveBeenCalledWith(
+        "ad_slot_viewed",
+        expect.objectContaining({
+          slot_name: "home_ranking",
+          ad_slot_id: "8139813658",
+          page_path: "/ko",
+          page_surface: "home",
+          viewport_width: 390,
+          viewport_height: 844,
+          ad_correlated_long_task_count: 0,
+        })
+      );
     });
 
     it("ad_slot_state_changed 에 슬롯 상태와 예약 크기를 전달한다", async () => {
@@ -361,14 +368,46 @@ describe("analytics — P0 helpers", () => {
         reservedWidth: 160,
       });
       await flushAsync();
-      expect(trackMock).toHaveBeenCalledWith("ad_slot_state_changed", {
-        slot_name: "site_rail_right",
-        ad_slot_id: "8139813658",
-        status: "unfilled",
-        page_path: undefined,
-        reserved_height: 600,
-        reserved_width: 160,
+      expect(trackMock).toHaveBeenCalledWith(
+        "ad_slot_state_changed",
+        expect.objectContaining({
+          slot_name: "site_rail_right",
+          ad_slot_id: "8139813658",
+          status: "unfilled",
+          page_path: undefined,
+          reserved_height: 600,
+          reserved_width: 160,
+          page_long_task_total_ms: 0,
+        })
+      );
+    });
+
+    it("web vital 이벤트에 고정 page path와 attribution을 전달한다", async () => {
+      analytics.webVitalReported({
+        name: "INP",
+        value: 189.6,
+        delta: 189.6,
+        id: "v4-test",
+        pagePath: "/ko/character/1",
+        attribution: {
+          inp_longest_script_is_ad: true,
+          inp_input_delay_ms: 82.4,
+        },
       });
+      await flushAsync();
+
+      expect(trackMock).toHaveBeenCalledWith(
+        "web_vital_measured",
+        expect.objectContaining({
+          metric_name: "INP",
+          value: 190,
+          page_path: "/ko/character/1",
+          page_surface: "character_detail",
+          inp_longest_script_is_ad: true,
+          inp_input_delay_ms: 82.4,
+          ad_delivery_state: "no_slot",
+        })
+      );
     });
   });
 

--- a/frontend/src/__tests__/characterAnalysisState.test.ts
+++ b/frontend/src/__tests__/characterAnalysisState.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import type { CharacterStatsResponse } from "@/app/api/character/stats/[characterCode]/route";
+import { mergeSuccessfulPatchStats } from "@/components/features/character-analysis/utils";
+
+function stats(id: string) {
+  return { patchVersion: id } as CharacterStatsResponse;
+}
+
+describe("mergeSuccessfulPatchStats", () => {
+  it("실패한 요청 결과만 있으면 기존 배열 참조를 유지한다", () => {
+    const current: (CharacterStatsResponse | null)[] = [];
+
+    const result = mergeSuccessfulPatchStats(current, 2, 0, null, null, true);
+
+    expect(result).toBe(current);
+    expect(result).toEqual([]);
+  });
+
+  it("성공한 요청 결과만 정해진 패치 위치에 저장한다", () => {
+    const current: (CharacterStatsResponse | null)[] = [];
+    const selected = stats("12.1");
+
+    const result = mergeSuccessfulPatchStats(current, 2, 0, selected, null, true);
+
+    expect(result).not.toBe(current);
+    expect(result).toEqual([selected, null]);
+  });
+
+  it("이미 저장된 동일 결과에는 새 배열을 만들지 않는다", () => {
+    const selected = stats("12.1");
+    const current = [selected, null];
+
+    const result = mergeSuccessfulPatchStats(current, 2, 0, selected, null, true);
+
+    expect(result).toBe(current);
+  });
+});

--- a/frontend/src/components/RootDocumentExtras.tsx
+++ b/frontend/src/components/RootDocumentExtras.tsx
@@ -14,7 +14,9 @@ export function RootDocumentExtras() {
       <AmplitudeLoader />
       <WebVitalsReporter />
       <GoogleAnalytics />
-      <AdSenseScript />
+      <Suspense fallback={null}>
+        <AdSenseScript />
+      </Suspense>
       <Suspense fallback={null}>
         <AdBlockRecoveryPrompt />
       </Suspense>

--- a/frontend/src/components/WebVitalsReporter.tsx
+++ b/frontend/src/components/WebVitalsReporter.tsx
@@ -1,17 +1,88 @@
 "use client";
 
 import { useEffect } from "react";
+import type { MetricWithAttribution } from "web-vitals";
+import {
+  getResourceHost,
+  isAdResourceUrl,
+  startAdPerformanceMonitoring,
+} from "@/lib/adPerformance";
 import { analytics } from "@/lib/analytics";
 
-type VitalName = "LCP" | "INP" | "CLS" | "TTFB" | "FCP";
+function roundTiming(value: number | undefined) {
+  return value === undefined ? undefined : Math.round(value * 10) / 10;
+}
 
-interface VitalMetric {
-  name: VitalName;
-  value: number;
-  delta: number;
-  id: string;
-  rating: "good" | "needs-improvement" | "poor";
-  navigationType?: string;
+function generateMetricTarget(node: Node | null) {
+  if (!(node instanceof Element)) return undefined;
+  const adSlot = node.closest<HTMLElement>("[data-ad-slot-name]");
+  const slotName = adSlot?.dataset.adSlotName;
+  return slotName ? `ad_slot:${slotName}` : undefined;
+}
+
+function getAttributionProperties(metric: MetricWithAttribution) {
+  if (metric.name === "INP") {
+    const { attribution } = metric;
+    const longestScript = attribution.longestScript;
+    const sourceUrl = longestScript?.entry.sourceURL;
+    return {
+      attribution_target: attribution.interactionTarget,
+      attribution_load_state: attribution.loadState,
+      inp_interaction_type: attribution.interactionType,
+      inp_input_delay_ms: roundTiming(attribution.inputDelay),
+      inp_processing_duration_ms: roundTiming(attribution.processingDuration),
+      inp_presentation_delay_ms: roundTiming(attribution.presentationDelay),
+      inp_longest_script_host: getResourceHost(sourceUrl),
+      inp_longest_script_is_ad: sourceUrl ? isAdResourceUrl(sourceUrl) : null,
+      inp_longest_script_subpart: longestScript?.subpart,
+      inp_longest_script_intersection_ms: roundTiming(longestScript?.intersectingDuration),
+      inp_total_script_ms: roundTiming(attribution.totalScriptDuration),
+      inp_total_style_layout_ms: roundTiming(attribution.totalStyleAndLayoutDuration),
+      inp_total_paint_ms: roundTiming(attribution.totalPaintDuration),
+      inp_total_unattributed_ms: roundTiming(attribution.totalUnattributedDuration),
+    };
+  }
+
+  if (metric.name === "LCP") {
+    const { attribution } = metric;
+    return {
+      attribution_target: attribution.target,
+      lcp_resource_host: getResourceHost(attribution.url),
+      lcp_resource_is_ad: attribution.url ? isAdResourceUrl(attribution.url) : null,
+      lcp_ttfb_ms: roundTiming(attribution.timeToFirstByte),
+      lcp_resource_load_delay_ms: roundTiming(attribution.resourceLoadDelay),
+      lcp_resource_load_duration_ms: roundTiming(attribution.resourceLoadDuration),
+      lcp_element_render_delay_ms: roundTiming(attribution.elementRenderDelay),
+    };
+  }
+
+  if (metric.name === "CLS") {
+    const { attribution } = metric;
+    const target = attribution.largestShiftTarget;
+    return {
+      attribution_target: target,
+      attribution_load_state: attribution.loadState,
+      cls_largest_shift_is_ad: target?.startsWith("ad_slot:") ?? false,
+      cls_largest_shift_time_ms: roundTiming(attribution.largestShiftTime),
+      cls_largest_shift_value: roundTiming(attribution.largestShiftValue),
+    };
+  }
+
+  if (metric.name === "FCP") {
+    return {
+      attribution_load_state: metric.attribution.loadState,
+      fcp_ttfb_ms: roundTiming(metric.attribution.timeToFirstByte),
+      fcp_first_byte_to_fcp_ms: roundTiming(metric.attribution.firstByteToFCP),
+    };
+  }
+
+  return {
+    ttfb_waiting_ms: roundTiming(metric.attribution.waitingDuration),
+    ttfb_cache_ms: roundTiming(metric.attribution.cacheDuration),
+    ttfb_dns_ms: roundTiming(metric.attribution.dnsDuration),
+    ttfb_connection_ms: roundTiming(metric.attribution.connectionDuration),
+    ttfb_request_ms: roundTiming(metric.attribution.requestDuration),
+  };
 }
 
 /**
@@ -22,8 +93,10 @@ interface VitalMetric {
 export function WebVitalsReporter() {
   useEffect(() => {
     let cancelled = false;
+    const pagePath = window.location.pathname;
+    startAdPerformanceMonitoring();
 
-    const forward = (metric: VitalMetric) => {
+    const forward = (metric: MetricWithAttribution) => {
       if (cancelled) return;
       analytics.webVitalReported({
         name: metric.name,
@@ -32,17 +105,20 @@ export function WebVitalsReporter() {
         id: metric.id,
         rating: metric.rating,
         navigationType: metric.navigationType,
+        pagePath,
+        attribution: getAttributionProperties(metric),
       });
     };
 
-    import("web-vitals")
+    import("web-vitals/attribution")
       .then(({ onLCP, onINP, onCLS, onTTFB, onFCP }) => {
         if (cancelled) return;
-        onLCP(forward);
-        onINP(forward);
-        onCLS(forward);
-        onTTFB(forward);
-        onFCP(forward);
+        const options = { generateTarget: generateMetricTarget };
+        onLCP(forward, options);
+        onINP(forward, { ...options, includeProcessedEventEntries: false });
+        onCLS(forward, options);
+        onTTFB(forward, options);
+        onFCP(forward, options);
       })
       .catch(() => {});
 

--- a/frontend/src/components/ads/AdSenseScript.tsx
+++ b/frontend/src/components/ads/AdSenseScript.tsx
@@ -2,7 +2,10 @@
 
 import { usePathname } from "next/navigation";
 import Script from "next/script";
-import { ADSENSE_CLIENT } from "@/components/ads/adsenseConfig";
+import { useEffect, useRef } from "react";
+import { ADSENSE_CLIENT, ADSENSE_PREVIEW } from "@/components/ads/adsenseConfig";
+import { markAdScriptError, markAdScriptLoaded, markAdScriptScheduled } from "@/lib/adPerformance";
+import { analytics } from "@/lib/analytics";
 
 const CONTENT_PATH_PREFIXES = [
   "/",
@@ -15,7 +18,7 @@ const CONTENT_PATH_PREFIXES = [
 ];
 
 function stripLocale(pathname: string) {
-  return pathname.replace(/^\/(?:ko|en|ja)(?=\/|$)/, "") || "/";
+  return pathname.replace(/^\/(?:ko|en|ja|zh-Hans|zh-Hant)(?=\/|$)/, "") || "/";
 }
 
 export function canLoadAds(pathname: string) {
@@ -27,8 +30,17 @@ export function canLoadAds(pathname: string) {
 
 export function AdSenseScript() {
   const pathname = usePathname();
-  if (!ADSENSE_CLIENT) return null;
-  if (!canLoadAds(pathname)) return null;
+  const trackedStates = useRef(new Set<"scheduled" | "loaded" | "error">());
+  const shouldLoad = !ADSENSE_PREVIEW && Boolean(ADSENSE_CLIENT) && canLoadAds(pathname);
+
+  useEffect(() => {
+    if (!shouldLoad || trackedStates.current.has("scheduled")) return;
+    trackedStates.current.add("scheduled");
+    markAdScriptScheduled();
+    analytics.adScriptStateChanged({ state: "scheduled" });
+  }, [shouldLoad]);
+
+  if (!shouldLoad) return null;
 
   return (
     <Script
@@ -37,6 +49,18 @@ export function AdSenseScript() {
       src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${ADSENSE_CLIENT}`}
       crossOrigin="anonymous"
       strategy="lazyOnload"
+      onLoad={() => {
+        if (trackedStates.current.has("loaded")) return;
+        trackedStates.current.add("loaded");
+        markAdScriptLoaded();
+        analytics.adScriptStateChanged({ state: "loaded" });
+      }}
+      onError={() => {
+        if (trackedStates.current.has("error")) return;
+        trackedStates.current.add("error");
+        markAdScriptError();
+        analytics.adScriptStateChanged({ state: "error" });
+      }}
     />
   );
 }

--- a/frontend/src/components/ads/AdSlot.tsx
+++ b/frontend/src/components/ads/AdSlot.tsx
@@ -3,11 +3,13 @@
 import { useLocale } from "next-intl";
 import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  ADSENSE_CHANNELS,
   ADSENSE_CLIENT,
   ADSENSE_PREVIEW,
   type AdSlotReservation,
 } from "@/components/ads/adsenseConfig";
 import type { RouteLocale } from "@/i18n/routing";
+import { markAdSlotState } from "@/lib/adPerformance";
 import { analytics, type AdSlotName } from "@/lib/analytics";
 
 declare global {
@@ -37,6 +39,8 @@ const AD_LABEL: Record<RouteLocale, string> = {
 };
 
 type AdSlotStatus = "reserved" | "requested" | "filled" | "unfilled" | "timeout";
+type TrackedAdSlotStatus = Exclude<AdSlotStatus, "reserved">;
+const AD_REQUEST_ROOT_MARGIN = "800px 0px";
 
 type AdSlotStyle = CSSProperties & {
   "--ad-reserved-height": string;
@@ -95,53 +99,96 @@ export function AdSlot({
   const pushedElement = useRef<HTMLModElement | null>(null);
   const renderedTracked = useRef(false);
   const viewedTracked = useRef(false);
-  const statusTracked = useRef<Set<AdSlotStatus>>(new Set());
+  const statusTracked = useRef<Set<TrackedAdSlotStatus>>(new Set());
+  const renderedAt = useRef<number | null>(null);
+  const requestedAt = useRef<number | null>(null);
+  const filledAt = useRef<number | null>(null);
   const [status, setStatus] = useState<AdSlotStatus>("reserved");
+  const slotKey = `${slotName}:${slot}`;
   const reservedStyle = useMemo(
     () => getReservationStyle(reservation, minHeight),
     [minHeight, reservation]
   );
 
   const trackStatus = useCallback(
-    (nextStatus: AdSlotStatus) => {
+    (nextStatus: TrackedAdSlotStatus) => {
       if (!slot || statusTracked.current.has(nextStatus)) return;
       statusTracked.current.add(nextStatus);
+      const currentTime = performance.now();
+      if (nextStatus === "requested" && requestedAt.current === null) {
+        requestedAt.current = currentTime;
+      }
+      if (nextStatus === "filled" && filledAt.current === null) {
+        filledAt.current = currentTime;
+      }
+      markAdSlotState(slotKey, nextStatus);
       analytics.adSlotStateChanged({
         slotName,
         adSlotId: slot,
         status: nextStatus,
         reservedHeight: getCurrentReservedHeight(reservation, minHeight),
         reservedWidth: reservation?.width ?? null,
+        elapsedSinceRenderMs:
+          renderedAt.current === null ? undefined : currentTime - renderedAt.current,
+        requestToStateMs:
+          requestedAt.current === null ? undefined : currentTime - requestedAt.current,
       });
     },
-    [minHeight, reservation, slot, slotName]
+    [minHeight, reservation, slot, slotKey, slotName]
   );
 
-  useEffect(() => {
+  const requestSlot = useCallback(() => {
     const element = insRef.current;
     if (ADSENSE_PREVIEW || !ADSENSE_CLIENT || !slot || !element) return;
     if (pushedElement.current === element) return;
     try {
       (window.adsbygoogle = window.adsbygoogle || []).push({});
       pushedElement.current = element;
+      setStatus("requested");
       trackStatus("requested");
     } catch {
-      // adsbygoogle may not be loaded yet; loader script will retry on script load
+      // A queued adsbygoogle command is normally accepted before the loader finishes.
     }
   }, [slot, trackStatus]);
+
+  useEffect(() => {
+    if (!slot || renderedTracked.current) return;
+    renderedTracked.current = true;
+    renderedAt.current = performance.now();
+    markAdSlotState(slotKey, "rendered");
+    analytics.adSlotRendered({
+      slotName,
+      adSlotId: slot,
+      reservedHeight: getCurrentReservedHeight(reservation, minHeight),
+      reservedWidth: reservation?.width ?? null,
+    });
+  }, [minHeight, reservation, slot, slotKey, slotName]);
+
+  useEffect(() => {
+    if (ADSENSE_PREVIEW || !ADSENSE_CLIENT || !slot) return;
+    const element = rootRef.current;
+    if (!element) return;
+    if (typeof IntersectionObserver === "undefined") {
+      const timeoutId = setTimeout(requestSlot, 0);
+      return () => clearTimeout(timeoutId);
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry?.isIntersecting) return;
+        requestSlot();
+        observer.disconnect();
+      },
+      { rootMargin: AD_REQUEST_ROOT_MARGIN, threshold: 0 }
+    );
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [requestSlot, slot]);
 
   useEffect(() => {
     if (ADSENSE_PREVIEW || !ADSENSE_CLIENT || !slot) return;
     const element = insRef.current;
     if (!element || typeof MutationObserver === "undefined") return;
-
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-
-    const clearStatusTimeout = () => {
-      if (!timeoutId) return;
-      clearTimeout(timeoutId);
-      timeoutId = null;
-    };
 
     const updateStatus = () => {
       const adStatus = element.getAttribute("data-ad-status");
@@ -149,42 +196,34 @@ export function AdSlot({
       if (!nextStatus) return;
       setStatus(nextStatus);
       trackStatus(nextStatus);
-      clearStatusTimeout();
     };
 
     const observer = new MutationObserver(updateStatus);
     observer.observe(element, { attributes: true, attributeFilter: ["data-ad-status"] });
 
-    timeoutId = setTimeout(() => {
+    updateStatus();
+
+    return () => observer.disconnect();
+  }, [slot, trackStatus]);
+
+  useEffect(() => {
+    if (status !== "requested") return;
+    const element = insRef.current;
+    if (!element) return;
+
+    const timeoutId = setTimeout(() => {
       if (element.getAttribute("data-ad-status")) return;
       if (element.querySelector("iframe")) return;
       setStatus("timeout");
       trackStatus("timeout");
-      timeoutId = null;
-    }, 6000);
+    }, 10_000);
 
-    updateStatus();
-
-    return () => {
-      observer.disconnect();
-      clearStatusTimeout();
-    };
-  }, [slot, trackStatus]);
+    return () => clearTimeout(timeoutId);
+  }, [status, trackStatus]);
 
   useEffect(() => {
-    if (!slot || renderedTracked.current) return;
-    renderedTracked.current = true;
-    analytics.adSlotRendered({
-      slotName,
-      adSlotId: slot,
-      reservedHeight: getCurrentReservedHeight(reservation, minHeight),
-      reservedWidth: reservation?.width ?? null,
-    });
-  }, [minHeight, reservation, slot, slotName]);
-
-  useEffect(() => {
-    if (!slot || viewedTracked.current) return;
-    const element = rootRef.current;
+    if (!slot || status !== "filled" || viewedTracked.current) return;
+    const element = insRef.current;
     if (!element || typeof IntersectionObserver === "undefined") return;
 
     let viewTimer: ReturnType<typeof setTimeout> | null = null;
@@ -201,12 +240,18 @@ export function AdSlot({
         if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
           if (viewTimer) return;
           viewTimer = setTimeout(() => {
+            const currentTime = performance.now();
             viewedTracked.current = true;
+            markAdSlotState(slotKey, "viewable");
             analytics.adSlotViewed({
               slotName,
               adSlotId: slot,
               reservedHeight: getCurrentReservedHeight(reservation, minHeight),
               reservedWidth: reservation?.width ?? null,
+              renderToViewableMs:
+                renderedAt.current === null ? undefined : currentTime - renderedAt.current,
+              fillToViewableMs:
+                filledAt.current === null ? undefined : currentTime - filledAt.current,
             });
             observer.disconnect();
           }, 1000);
@@ -223,7 +268,7 @@ export function AdSlot({
       clearViewTimer();
       observer.disconnect();
     };
-  }, [minHeight, reservation, slot, slotName]);
+  }, [minHeight, reservation, slot, slotKey, slotName, status]);
 
   if (ADSENSE_PREVIEW) {
     return (
@@ -232,6 +277,7 @@ export function AdSlot({
         className={`ad-placement ad-placement-preview ${className ?? ""}`}
         style={reservedStyle}
         data-ad-slot-name={slotName}
+        data-ad-slot-key={slotKey}
         data-ad-slot-status="preview"
       >
         <span className="ad-placement-label">{label}</span>
@@ -250,6 +296,7 @@ export function AdSlot({
       className={`ad-placement ${className ?? ""}`}
       style={reservedStyle}
       data-ad-slot-name={slotName}
+      data-ad-slot-key={slotKey}
       data-ad-slot-status={status}
     >
       <span className="ad-placement-label">{label}</span>
@@ -260,6 +307,7 @@ export function AdSlot({
         style={{ display: "block", minHeight: 0, width: "100%", height: "100%" }}
         data-ad-client={ADSENSE_CLIENT}
         data-ad-slot={slot}
+        data-ad-channel={ADSENSE_CHANNELS[slotName] || undefined}
         data-ad-format={format}
         data-ad-layout={layout}
         data-ad-layout-key={layoutKey}

--- a/frontend/src/components/ads/adsenseConfig.ts
+++ b/frontend/src/components/ads/adsenseConfig.ts
@@ -67,6 +67,18 @@ export const ADSENSE_SLOTS = {
     : (process.env.NEXT_PUBLIC_ADSENSE_SITE_RAIL_RIGHT_SLOT ?? productionDefault),
 } as const;
 
+/**
+ * Optional AdSense custom channels. Assign one channel per placement in AdSense so revenue and
+ * Active View can be joined with the client-side slot_name funnel without tracking ad clicks.
+ */
+export const ADSENSE_CHANNELS = {
+  home_ranking: process.env.NEXT_PUBLIC_ADSENSE_HOME_RANKING_CHANNEL ?? "",
+  synergy_detail_top: process.env.NEXT_PUBLIC_ADSENSE_SYNERGY_DETAIL_CHANNEL ?? "",
+  character_analysis_top: process.env.NEXT_PUBLIC_ADSENSE_CHARACTER_ANALYSIS_CHANNEL ?? "",
+  site_rail_left: process.env.NEXT_PUBLIC_ADSENSE_SITE_RAIL_LEFT_CHANNEL ?? "",
+  site_rail_right: process.env.NEXT_PUBLIC_ADSENSE_SITE_RAIL_RIGHT_CHANNEL ?? "",
+} as const;
+
 export function canRenderAdSlot(slot: string) {
   return ADSENSE_PREVIEW || (Boolean(ADSENSE_CLIENT) && Boolean(slot));
 }

--- a/frontend/src/components/features/character-analysis/CharacterAnalysisClient.tsx
+++ b/frontend/src/components/features/character-analysis/CharacterAnalysisClient.tsx
@@ -21,7 +21,7 @@ import {
 import { computeCharacterMetaTiers } from "../tier-ranking/utils";
 import { CharacterHeader } from "./CharacterHeader";
 import { RoleComboRpPanel } from "./RoleComboRpPanel";
-import { fetchStats, fetchStatsHistory } from "./utils";
+import { fetchStats, fetchStatsHistory, mergeSuccessfulPatchStats } from "./utils";
 
 // 탭 콘텐츠: lazy import (코드 스플릿)
 const PatchComparisonTab = React.lazy(() =>
@@ -385,15 +385,16 @@ export function CharacterAnalysisClient({
       ]);
       if (cancelled) return;
 
-      setAllPatchStats((prev) => {
-        const merged =
-          prev.length === patches.length ? [...prev] : Array(patches.length).fill(null);
-        merged[selectedPatchIndex] = selectedResult ?? null;
-        if (selectedPreviousPatch) {
-          merged[selectedPatchIndex + 1] = previousResult;
-        }
-        return merged;
-      });
+      setAllPatchStats((prev) =>
+        mergeSuccessfulPatchStats(
+          prev,
+          patches.length,
+          selectedPatchIndex,
+          selectedResult,
+          previousResult,
+          Boolean(selectedPreviousPatch)
+        )
+      );
       setSelectedWeapon(
         readWeaponFromLocation() ?? selectedResult?.weapons?.[0]?.bestWeapon ?? null
       );

--- a/frontend/src/components/features/character-analysis/utils.ts
+++ b/frontend/src/components/features/character-analysis/utils.ts
@@ -1,5 +1,31 @@
 import type { CharacterStatsResponse } from "@/app/api/character/stats/[characterCode]/route";
 
+export function mergeSuccessfulPatchStats(
+  current: (CharacterStatsResponse | null)[],
+  patchCount: number,
+  selectedPatchIndex: number,
+  selectedResult: CharacterStatsResponse | null,
+  previousResult: CharacterStatsResponse | null,
+  includePreviousPatch: boolean
+) {
+  let merged = current;
+
+  const writeResult = (index: number, result: CharacterStatsResponse | null) => {
+    if (!result || index < 0 || index >= patchCount || merged[index] === result) return;
+    if (merged === current) {
+      merged = current.length === patchCount ? [...current] : Array(patchCount).fill(null);
+    }
+    merged[index] = result;
+  };
+
+  writeResult(selectedPatchIndex, selectedResult);
+  if (includePreviousPatch) {
+    writeResult(selectedPatchIndex + 1, previousResult);
+  }
+
+  return merged;
+}
+
 export async function fetchStats(
   characterCode: number,
   patchVersion: string,

--- a/frontend/src/lib/adPerformance.ts
+++ b/frontend/src/lib/adPerformance.ts
@@ -1,0 +1,329 @@
+export type AdScriptState = "not_scheduled" | "scheduled" | "loading" | "loaded" | "error";
+export type AdDeliveryState =
+  | "no_slot"
+  | "slot_only"
+  | "requested"
+  | "filled"
+  | "viewable"
+  | "blocked_or_failed";
+
+export type AdSlotLifecycleState =
+  | "rendered"
+  | "requested"
+  | "filled"
+  | "unfilled"
+  | "timeout"
+  | "viewable";
+
+export interface AdPerformanceSnapshot {
+  scriptState: AdScriptState;
+  scriptLoadMs: number | null;
+  deliveryState: AdDeliveryState;
+  renderedSlotCount: number;
+  requestedSlotCount: number;
+  filledSlotCount: number;
+  viewableSlotCount: number;
+  failedSlotCount: number;
+  adResourceCount: number;
+  adResourceDurationMs: number;
+  adTransferKb: number | null;
+  pageLongTaskCount: number;
+  pageLongTaskTotalMs: number;
+  pageLongTaskMaxMs: number;
+  adFrameLongTaskCount: number;
+  adFrameLongTaskTotalMs: number;
+  adCorrelatedLongTaskCount: number;
+  adCorrelatedLongTaskTotalMs: number;
+}
+
+interface RecordedResource {
+  key: string;
+  startTime: number;
+  responseEnd: number;
+  duration: number;
+  transferSize: number;
+  isLoader: boolean;
+}
+
+interface RecordedLongTask {
+  key: string;
+  startTime: number;
+  duration: number;
+  directlyAttributedToAdFrame: boolean;
+}
+
+interface AdActivity {
+  at: number;
+}
+
+interface LongTaskAttributionLike {
+  containerSrc?: string;
+}
+
+interface LongTaskEntryLike extends PerformanceEntry {
+  attribution?: LongTaskAttributionLike[];
+}
+
+const AD_HOST_SUFFIXES = [
+  "googlesyndication.com",
+  "doubleclick.net",
+  "googleadservices.com",
+  "googletagservices.com",
+] as const;
+const ADSENSE_LOADER_PATH = "/pagead/js/adsbygoogle.js";
+const AD_ACTIVITY_CORRELATION_WINDOW_MS = 2_000;
+const MAX_RECORDED_ENTRIES = 250;
+
+const slotHistory = new Map<string, Set<AdSlotLifecycleState>>();
+const resources: RecordedResource[] = [];
+const resourceKeys = new Set<string>();
+const longTasks: RecordedLongTask[] = [];
+const longTaskKeys = new Set<string>();
+const adActivities: AdActivity[] = [];
+const observers: PerformanceObserver[] = [];
+
+let monitoringStarted = false;
+let scriptState: AdScriptState = "not_scheduled";
+let scriptResourceStart: number | null = null;
+let scriptLoadedAt: number | null = null;
+
+function now() {
+  return typeof performance !== "undefined" ? performance.now() : 0;
+}
+
+function round(value: number) {
+  return Math.round(value * 10) / 10;
+}
+
+function addBounded<T>(items: T[], item: T) {
+  items.push(item);
+  if (items.length > MAX_RECORDED_ENTRIES) items.shift();
+}
+
+function noteAdActivity(at = now()) {
+  addBounded(adActivities, { at });
+}
+
+export function getResourceHost(value: string | undefined): string | null {
+  if (!value) return null;
+  try {
+    return new URL(value, typeof window !== "undefined" ? window.location.href : undefined).hostname
+      .toLowerCase()
+      .replace(/^www\./, "");
+  } catch {
+    return null;
+  }
+}
+
+export function isAdResourceUrl(value: string | undefined) {
+  const host = getResourceHost(value);
+  if (!host) return false;
+  return AD_HOST_SUFFIXES.some((suffix) => host === suffix || host.endsWith(`.${suffix}`));
+}
+
+function isAdsenseLoader(value: string) {
+  if (!isAdResourceUrl(value)) return false;
+  try {
+    return new URL(value).pathname.endsWith(ADSENSE_LOADER_PATH);
+  } catch {
+    return value.includes(ADSENSE_LOADER_PATH);
+  }
+}
+
+function recordResource(entry: PerformanceResourceTiming) {
+  if (!isAdResourceUrl(entry.name)) return;
+  const key = `${entry.name}:${round(entry.startTime)}:${round(entry.duration)}`;
+  if (resourceKeys.has(key)) return;
+  resourceKeys.add(key);
+
+  const responseEnd = entry.responseEnd || entry.startTime + entry.duration;
+  const isLoader = isAdsenseLoader(entry.name);
+  addBounded(resources, {
+    key,
+    startTime: entry.startTime,
+    responseEnd,
+    duration: entry.duration,
+    transferSize: entry.transferSize,
+    isLoader,
+  });
+  noteAdActivity(responseEnd);
+
+  if (isLoader) {
+    scriptResourceStart =
+      scriptResourceStart === null
+        ? entry.startTime
+        : Math.min(scriptResourceStart, entry.startTime);
+    if (scriptState === "scheduled") scriptState = "loading";
+  }
+}
+
+function recordLongTask(entry: PerformanceEntry) {
+  const longTask = entry as LongTaskEntryLike;
+  const key = `${round(longTask.startTime)}:${round(longTask.duration)}`;
+  if (longTaskKeys.has(key)) return;
+  longTaskKeys.add(key);
+
+  const directlyAttributedToAdFrame =
+    longTask.attribution?.some((attribution) => isAdResourceUrl(attribution.containerSrc)) ?? false;
+  addBounded(longTasks, {
+    key,
+    startTime: longTask.startTime,
+    duration: longTask.duration,
+    directlyAttributedToAdFrame,
+  });
+}
+
+function observeEntryType(
+  type: "resource" | "longtask",
+  callback: (entry: PerformanceEntry) => void
+) {
+  if (typeof PerformanceObserver === "undefined") return;
+  if (!PerformanceObserver.supportedEntryTypes?.includes(type)) return;
+
+  try {
+    const observer = new PerformanceObserver((list) => {
+      list.getEntries().forEach(callback);
+    });
+    observer.observe({ type, buffered: true });
+    observers.push(observer);
+  } catch {
+    // Performance entry support differs by browser; unsupported observers are optional RUM data.
+  }
+}
+
+export function startAdPerformanceMonitoring() {
+  if (monitoringStarted || typeof window === "undefined") return;
+  monitoringStarted = true;
+
+  if (typeof performance !== "undefined") {
+    performance
+      .getEntriesByType("resource")
+      .forEach((entry) => recordResource(entry as PerformanceResourceTiming));
+  }
+
+  observeEntryType("resource", (entry) => recordResource(entry as PerformanceResourceTiming));
+  observeEntryType("longtask", recordLongTask);
+}
+
+export function markAdScriptScheduled() {
+  startAdPerformanceMonitoring();
+  if (scriptState === "not_scheduled") scriptState = "scheduled";
+}
+
+export function markAdScriptLoaded() {
+  startAdPerformanceMonitoring();
+  scriptState = "loaded";
+  scriptLoadedAt = now();
+  noteAdActivity(scriptLoadedAt);
+}
+
+export function markAdScriptError() {
+  startAdPerformanceMonitoring();
+  scriptState = "error";
+  noteAdActivity();
+}
+
+export function markAdSlotState(slotKey: string, state: AdSlotLifecycleState) {
+  startAdPerformanceMonitoring();
+  const history = slotHistory.get(slotKey) ?? new Set<AdSlotLifecycleState>();
+  history.add(state);
+  slotHistory.set(slotKey, history);
+  if (state !== "rendered") noteAdActivity();
+}
+
+function getActiveSlotHistories() {
+  if (typeof document === "undefined") return [...slotHistory.entries()];
+  const activeKeys = new Set(
+    [...document.querySelectorAll<HTMLElement>("[data-ad-slot-key]")]
+      .map((element) => element.dataset.adSlotKey)
+      .filter((key): key is string => Boolean(key))
+  );
+  return [...slotHistory.entries()].filter(([key]) => activeKeys.has(key));
+}
+
+function countSlotsWith(
+  histories: Array<[string, Set<AdSlotLifecycleState>]>,
+  state: AdSlotLifecycleState
+) {
+  let count = 0;
+  histories.forEach(([, history]) => {
+    if (history.has(state)) count += 1;
+  });
+  return count;
+}
+
+function getDeliveryState(counts: {
+  rendered: number;
+  requested: number;
+  filled: number;
+  viewable: number;
+  failed: number;
+}): AdDeliveryState {
+  if (counts.rendered === 0) return "no_slot";
+  if (counts.viewable > 0) return "viewable";
+  if (counts.filled > 0) return "filled";
+  if (scriptState === "error" || counts.failed > 0) return "blocked_or_failed";
+  if (counts.requested > 0) return "requested";
+  return "slot_only";
+}
+
+function isTemporallyCorrelated(task: RecordedLongTask) {
+  if (task.directlyAttributedToAdFrame) return true;
+  const taskEnd = task.startTime + task.duration;
+  return adActivities.some(
+    (activity) =>
+      task.startTime <= activity.at + AD_ACTIVITY_CORRELATION_WINDOW_MS && taskEnd >= activity.at
+  );
+}
+
+function sumDuration(entries: Array<{ duration: number }>) {
+  return entries.reduce((sum, entry) => sum + entry.duration, 0);
+}
+
+export function getAdPerformanceSnapshot(): AdPerformanceSnapshot {
+  const activeSlotHistories = getActiveSlotHistories();
+  const renderedSlotCount = countSlotsWith(activeSlotHistories, "rendered");
+  const requestedSlotCount = countSlotsWith(activeSlotHistories, "requested");
+  const filledSlotCount = countSlotsWith(activeSlotHistories, "filled");
+  const viewableSlotCount = countSlotsWith(activeSlotHistories, "viewable");
+  const failedSlotCount = new Set(
+    activeSlotHistories
+      .filter(([, history]) => history.has("unfilled") || history.has("timeout"))
+      .map(([key]) => key)
+  ).size;
+  const directlyAttributedTasks = longTasks.filter((task) => task.directlyAttributedToAdFrame);
+  const correlatedTasks = longTasks.filter(isTemporallyCorrelated);
+  const transferredBytes = resources.reduce((sum, entry) => sum + entry.transferSize, 0);
+  const scriptLoadMs =
+    scriptResourceStart !== null && scriptLoadedAt !== null
+      ? Math.max(0, scriptLoadedAt - scriptResourceStart)
+      : null;
+
+  return {
+    scriptState,
+    scriptLoadMs: scriptLoadMs === null ? null : round(scriptLoadMs),
+    deliveryState: getDeliveryState({
+      rendered: renderedSlotCount,
+      requested: requestedSlotCount,
+      filled: filledSlotCount,
+      viewable: viewableSlotCount,
+      failed: failedSlotCount,
+    }),
+    renderedSlotCount,
+    requestedSlotCount,
+    filledSlotCount,
+    viewableSlotCount,
+    failedSlotCount,
+    adResourceCount: resources.length,
+    adResourceDurationMs: round(sumDuration(resources)),
+    // Cross-origin Resource Timing may expose 0 without Timing-Allow-Origin.
+    adTransferKb: transferredBytes > 0 ? round(transferredBytes / 1024) : null,
+    pageLongTaskCount: longTasks.length,
+    pageLongTaskTotalMs: round(sumDuration(longTasks)),
+    pageLongTaskMaxMs: round(Math.max(0, ...longTasks.map((task) => task.duration))),
+    adFrameLongTaskCount: directlyAttributedTasks.length,
+    adFrameLongTaskTotalMs: round(sumDuration(directlyAttributedTasks)),
+    adCorrelatedLongTaskCount: correlatedTasks.length,
+    adCorrelatedLongTaskTotalMs: round(sumDuration(correlatedTasks)),
+  };
+}

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -3,6 +3,7 @@ import {
   type AdBlockRecoveryDismissReason,
   type AdBlockRecoveryVariant,
 } from "@/lib/adBlockRecoveryExperiment";
+import { getAdPerformanceSnapshot, type AdScriptState } from "@/lib/adPerformance";
 
 type AmplitudeModule = typeof import("@amplitude/analytics-browser");
 
@@ -39,6 +40,44 @@ function trackAdBlockRecovery(event: string, properties: FlatAnalyticsProperties
 function getCurrentPagePath() {
   if (typeof window === "undefined") return undefined;
   return window.location?.pathname;
+}
+
+function getPageSurface(pagePath: string | undefined) {
+  if (!pagePath) return "unknown";
+  const path = pagePath.replace(/^\/(?:ko|en|ja|zh-Hans|zh-Hant)(?=\/|$)/, "") || "/";
+  if (path === "/") return "home";
+  if (path.startsWith("/character/")) return "character_detail";
+  if (path.startsWith("/character-analysis")) return "character_analysis";
+  if (path.startsWith("/synergy-detail")) return "synergy_detail";
+  if (path.startsWith("/patch-analysis")) return "patch_analysis";
+  if (path.startsWith("/patches")) return "patches";
+  if (path.startsWith("/about")) return "about";
+  if (path.startsWith("/methodology")) return "methodology";
+  return "other";
+}
+
+function getAdPerformanceProperties() {
+  const snapshot = getAdPerformanceSnapshot();
+  return {
+    ad_script_state: snapshot.scriptState,
+    ad_script_load_ms: snapshot.scriptLoadMs,
+    ad_delivery_state: snapshot.deliveryState,
+    ad_rendered_slot_count: snapshot.renderedSlotCount,
+    ad_requested_slot_count: snapshot.requestedSlotCount,
+    ad_filled_slot_count: snapshot.filledSlotCount,
+    ad_viewable_slot_count: snapshot.viewableSlotCount,
+    ad_failed_slot_count: snapshot.failedSlotCount,
+    ad_resource_count: snapshot.adResourceCount,
+    ad_resource_duration_ms: snapshot.adResourceDurationMs,
+    ad_transfer_kb: snapshot.adTransferKb,
+    page_long_task_count: snapshot.pageLongTaskCount,
+    page_long_task_total_ms: snapshot.pageLongTaskTotalMs,
+    page_long_task_max_ms: snapshot.pageLongTaskMaxMs,
+    ad_frame_long_task_count: snapshot.adFrameLongTaskCount,
+    ad_frame_long_task_total_ms: snapshot.adFrameLongTaskTotalMs,
+    ad_correlated_long_task_count: snapshot.adCorrelatedLongTaskCount,
+    ad_correlated_long_task_total_ms: snapshot.adCorrelatedLongTaskTotalMs,
+  };
 }
 
 // ── Types (pm/amplitude-event-design.md §3.3) ────────────────────────────────
@@ -316,12 +355,15 @@ export const analytics = {
     reservedHeight?: number;
     reservedWidth?: number | null;
   }) {
+    const pagePath = args.pagePath ?? getCurrentPagePath();
     track("ad_slot_rendered", {
       slot_name: args.slotName,
       ad_slot_id: args.adSlotId,
-      page_path: args.pagePath ?? getCurrentPagePath(),
+      page_path: pagePath,
+      page_surface: getPageSurface(pagePath),
       reserved_height: args.reservedHeight,
       reserved_width: args.reservedWidth,
+      ...getAdPerformanceProperties(),
     });
   },
 
@@ -332,7 +374,10 @@ export const analytics = {
     pagePath?: string;
     reservedHeight?: number;
     reservedWidth?: number | null;
+    renderToViewableMs?: number;
+    fillToViewableMs?: number;
   }) {
+    const pagePath = args.pagePath ?? getCurrentPagePath();
     const viewport =
       typeof window !== "undefined"
         ? {
@@ -344,11 +389,15 @@ export const analytics = {
     track("ad_slot_viewed", {
       slot_name: args.slotName,
       ad_slot_id: args.adSlotId,
-      page_path: args.pagePath ?? getCurrentPagePath(),
+      page_path: pagePath,
+      page_surface: getPageSurface(pagePath),
       viewport_width: viewport?.width,
       viewport_height: viewport?.height,
       reserved_height: args.reservedHeight,
       reserved_width: args.reservedWidth,
+      render_to_viewable_ms: args.renderToViewableMs,
+      fill_to_viewable_ms: args.fillToViewableMs,
+      ...getAdPerformanceProperties(),
     });
   },
 
@@ -359,14 +408,32 @@ export const analytics = {
     status: AdSlotStatus;
     reservedHeight: number;
     reservedWidth: number | null;
+    elapsedSinceRenderMs?: number;
+    requestToStateMs?: number;
   }) {
+    const pagePath = getCurrentPagePath();
     track("ad_slot_state_changed", {
       slot_name: args.slotName,
       ad_slot_id: args.adSlotId,
       status: args.status,
-      page_path: getCurrentPagePath(),
+      page_path: pagePath,
+      page_surface: getPageSurface(pagePath),
       reserved_height: args.reservedHeight,
       reserved_width: args.reservedWidth,
+      elapsed_since_render_ms: args.elapsedSinceRenderMs,
+      request_to_state_ms: args.requestToStateMs,
+      ...getAdPerformanceProperties(),
+    });
+  },
+
+  /** AdSense loader 자체의 예약/로드/실패 상태와 그 시점까지의 main-thread 비용. */
+  adScriptStateChanged(args: { state: Exclude<AdScriptState, "not_scheduled" | "loading"> }) {
+    const pagePath = getCurrentPagePath();
+    track("ad_script_state_changed", {
+      state: args.state,
+      page_path: pagePath,
+      page_surface: getPageSurface(pagePath),
+      ...getAdPerformanceProperties(),
     });
   },
 
@@ -480,8 +547,10 @@ export const analytics = {
     id: string;
     rating?: "good" | "needs-improvement" | "poor";
     navigationType?: string;
+    pagePath?: string;
+    attribution?: Record<string, string | number | boolean | null | undefined>;
   }) {
-    const pagePath = getCurrentPagePath();
+    const pagePath = metric.pagePath ?? getCurrentPagePath();
     const connection =
       typeof navigator !== "undefined"
         ? (navigator as unknown as { connection?: { effectiveType?: string } }).connection
@@ -498,11 +567,14 @@ export const analytics = {
       rating: metric.rating,
       navigation_type: metric.navigationType,
       page_path: pagePath,
+      page_surface: getPageSurface(pagePath),
       effective_connection_type: connection?.effectiveType,
       ad_slots_present:
         typeof document !== "undefined"
           ? document.querySelectorAll("[data-ad-slot-name]").length
           : 0,
+      ...metric.attribution,
+      ...getAdPerformanceProperties(),
     });
   },
 };

--- a/pm/ad-monetization-performance-measurement.md
+++ b/pm/ad-monetization-performance-measurement.md
@@ -1,0 +1,158 @@
+# 광고 Viewability 퍼널·성능 비용 계측
+
+> 작성일: 2026-08-27
+>
+> 목적: 광고 수익화를 유지하면서 `request → fill → viewable` 병목과 광고가 Web Vitals에 더하는 비용을 같은 릴리스 단위에서 판단한다.
+
+## 1. 측정 질문
+
+1. 렌더 가능한 광고 슬롯 중 실제 요청, fill, viewable까지 도달하는 비율은 얼마인가?
+2. 광고가 정상 fill된 방문과 광고가 없거나 실패한 방문의 INP/LCP/CLS p75 차이는 얼마인가?
+3. INP 후보와 직접 겹친 광고 스크립트 또는 광고 iframe Long Task가 있는가?
+4. 어떤 `page_surface × slot_name` 개선이 가장 많은 viewable impression과 실제 수익을 회수하는가?
+
+Google Active View와 같은 기준으로, 클라이언트의 viewable은 **광고가 fill된 뒤 광고 영역의 50% 이상이 1초 연속 viewport에 머문 경우**로 정의한다. 이 이벤트는 AdSense 공식 집계를 대체하지 않고 퍼널 진단용으로 쓴다.
+
+## 2. 구현된 계측
+
+### 광고 퍼널
+
+| 단계        | 이벤트/필터                                           | 의미                                     |
+| ----------- | ----------------------------------------------------- | ---------------------------------------- |
+| Opportunity | `ad_slot_rendered`                                    | 슬롯 DOM과 예약 공간이 생성됨            |
+| Request     | `ad_slot_state_changed`, `status=requested`           | `adsbygoogle.push`가 중복 없이 queue됨   |
+| Fill        | `ad_slot_state_changed`, `status=filled`              | AdSense가 `data-ad-status=filled`로 응답 |
+| Viewable    | `ad_slot_viewed`                                      | fill 후 50%/1초 조건 충족                |
+| Failure     | `ad_slot_state_changed`, `status=unfilled or timeout` | fill 실패 또는 10초 내 응답 없음         |
+
+`ad_slot_viewed`에는 `render_to_viewable_ms`, `fill_to_viewable_ms`가 포함된다. 상태 이벤트에는 `elapsed_since_render_ms`, `request_to_state_ms`가 포함되어 request→fill 지연의 p50/p75/p95를 바로 계산할 수 있다.
+
+### 광고 성능 문맥
+
+모든 광고 이벤트와 `web_vital_measured`에 다음 저 cardinality 속성을 붙인다.
+
+| 속성                                                             | 용도                                                                                                             |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `page_surface`                                                   | `home`, `character_detail`, `character_analysis`, `synergy_detail`, `patches`, `patch_analysis` 등 페이지군 비교 |
+| `ad_delivery_state`                                              | `no_slot`, `slot_only`, `requested`, `filled`, `viewable`, `blocked_or_failed` 코호트 분리                       |
+| `ad_*_slot_count`                                                | 한 문서에서 단계별로 도달한 슬롯 수                                                                              |
+| `ad_resource_count`, `ad_resource_duration_ms`, `ad_transfer_kb` | Resource Timing 기반 광고 네트워크 비용. TAO가 없는 응답의 transfer size는 `null`                                |
+| `page_long_task_*`                                               | 페이지 전체 Long Task 개수·합·최댓값                                                                             |
+| `ad_frame_long_task_*`                                           | Long Tasks attribution의 iframe `containerSrc`가 광고 도메인인 직접 귀속 비용                                    |
+| `ad_correlated_long_task_*`                                      | 광고 응답/요청 후 2초 안에 겹친 시간 상관 비용. 인과로 표현하지 않음                                             |
+| `ad_script_state`, `ad_script_load_ms`                           | AdSense loader 예약/성공/실패와 Resource Timing 기반 로드 시간                                                   |
+
+`web-vitals/attribution`으로 INP를 `input delay / processing / presentation`으로 나누고, LoAF가 지원되는 브라우저에서는 INP와 가장 오래 겹친 script host 및 광고 도메인 여부도 전송한다. CLS는 가장 큰 shift target이 `ad_slot:*`인지 별도로 기록한다.
+
+초기 문서 경로를 `WebVitalsReporter` mount 시 고정한다. 사용자가 SPA 라우팅 후 탭을 닫아도 최초 navigation의 Web Vital이 마지막 URL로 잘못 귀속되지 않는다.
+
+## 3. 로딩 전략 변경
+
+- AdSense loader는 기존처럼 Next.js `lazyOnload + async`를 유지한다.
+- 각 수동 슬롯은 viewport 기준 상하 800px 안에 들어온 뒤에만 request한다.
+- `display:none`인 모바일/좁은 데스크톱 rail은 IntersectionObserver에 들어오지 않으므로 불필요한 request를 만들지 않는다.
+- 슬롯별 DOM element ref로 `adsbygoogle.push`를 1회만 허용한다.
+- 슬롯 높이는 breakpoint별로 계속 사전 예약해 CLS를 방어한다.
+- viewability observer는 root placeholder가 아니라 **fill된 `<ins>` 영역**만 관찰한다.
+
+이 변경 전후 비교에서는 `app_version`을 release filter로 반드시 사용한다. viewable의 의미가 “빈 슬롯 포함 가능”에서 “fill 광고만”으로 바뀌었기 때문에 단순 시계열을 이어 붙이면 안 된다.
+
+## 4. Amplitude 차트
+
+### 4.1 Viewability 퍼널
+
+```text
+Chart Type: Funnel
+Step 1: ad_slot_rendered
+Step 2: ad_slot_state_changed WHERE status = requested
+Step 3: ad_slot_state_changed WHERE status = filled
+Step 4: ad_slot_viewed
+Conversion Window: 30 seconds
+Group by: slot_name 또는 page_surface
+Measure: Totals
+```
+
+같이 보는 비율:
+
+- Request rate = requested / rendered
+- Fill rate = filled / requested
+- Viewability = viewed / filled
+- 요청 낭비율 = 1 - requested / rendered (의도적인 viewport 지연 포함)
+- Fill 실패율 = (unfilled + timeout) / requested
+
+### 4.2 광고 코호트별 Web Vitals 비용
+
+```text
+Event: web_vital_measured
+Metric: p75(value)
+Filter: metric_name = INP (LCP, CLS 각각 별도 차트)
+Group by: ad_delivery_state
+Secondary group/filter: page_surface, is_mobile_viewport, effective_connection_type, app_version
+```
+
+핵심 비교:
+
+```text
+광고 정상: ad_filled_slot_count >= 1
+광고 없음/실패: ad_filled_slot_count = 0
+직접 광고 script 증거: inp_longest_script_is_ad = true
+직접 광고 iframe 증거: ad_frame_long_task_count >= 1
+시간 상관만 존재: ad_correlated_long_task_count >= 1 AND ad_frame_long_task_count = 0
+```
+
+관찰 코호트 비교는 페이지 종류, 디바이스, 네트워크, 광고 차단 사용자 차이의 영향을 받는다. 먼저 이 데이터로 병목을 찾고, 표본이 충분해지면 작은 무광고 holdout으로 인과 효과를 검증한다. holdout 없이 “광고가 INP를 N ms 악화시켰다”고 단정하지 않는다.
+
+### 4.3 페이지·슬롯 우선순위
+
+```text
+Event: ad_slot_viewed
+Measure: Totals / Uniques
+Group by: page_surface, slot_name
+Compare with: session_start 또는 page_view
+```
+
+클라이언트 이벤트만으로 실제 광고 수익을 계산하지 않는다. AdSense에서 각 placement에 별도 custom channel ID를 만들고 아래 환경 변수에 연결한다.
+
+```text
+NEXT_PUBLIC_ADSENSE_HOME_RANKING_CHANNEL
+NEXT_PUBLIC_ADSENSE_SYNERGY_DETAIL_CHANNEL
+NEXT_PUBLIC_ADSENSE_CHARACTER_ANALYSIS_CHANNEL
+NEXT_PUBLIC_ADSENSE_SITE_RAIL_LEFT_CHANNEL
+NEXT_PUBLIC_ADSENSE_SITE_RAIL_RIGHT_CHANNEL
+```
+
+AdSense 일별 custom-channel report의 `impressions, Active View viewable, estimated earnings, impression RPM`을 `channel ↔ slot_name` 매핑으로 합친다. 클릭 DOM 이벤트는 수집하지 않는다.
+
+권장 우선순위 표:
+
+| page_surface     | slot_name              | PV share | fill rate | viewability | revenue share | INP p75 delta | 결정 |
+| ---------------- | ---------------------- | -------: | --------: | ----------: | ------------: | ------------: | ---- |
+| home             | home_ranking           |          |           |             |               |               |      |
+| character_detail | character_analysis_top |          |           |             |               |               |      |
+| synergy_detail   | synergy_detail_top     |          |           |             |               |               |      |
+| shared           | site_rail_left/right   |          |           |             |               |               |      |
+
+수익 share가 높고 INP/CLS 비용도 큰 슬롯은 로딩 최적화 우선, 수익 share와 viewability가 모두 낮은 슬롯은 제거/이동 검토 대상으로 둔다.
+
+## 5. 운영 순서와 성공 기준
+
+1. 배포 후 7일간 이벤트 누락, unknown/timeout 비율, 속성 cardinality를 검증한다.
+2. `page_surface × device × connection`으로 보정한 광고 fill 유무별 Web Vitals p75 baseline을 만든다.
+3. INP poor 표본에서 `inp_longest_script_is_ad`, `ad_frame_long_task_count`, `ad_correlated_long_task_count` 순으로 직접성을 확인한다.
+4. AdSense custom channel report를 연결해 실제 revenue share를 채운다.
+5. 한 번에 하나의 로딩 전략만 변경하고 `app_version` 전후로 viewability/revenue와 Web Vitals를 같이 비교한다.
+
+초기 guardrail:
+
+- CLS p75 ≤ 0.1
+- INP p75 ≤ 200ms
+- LCP p75 ≤ 2.5s
+- Fill rate 또는 AdSense estimated earnings가 유의하게 하락하면 로딩 margin을 재조정
+- 광고 성능 속성 때문에 `web_vital_measured` 이벤트 전송량이 늘어나지 않아야 함
+
+## 참고
+
+- [Google AdSense: Viewability and Active View](https://support.google.com/adsense/answer/4510652?hl=en)
+- [Google AdSense: custom channels로 ad unit 성과 추적](https://support.google.com/adsense/answer/10078316?hl=en)
+- [GoogleChrome/web-vitals attribution build](https://github.com/GoogleChrome/web-vitals#attribution)
+- [web.dev: third-party JavaScript와 Long Tasks](https://web.dev/articles/optimizing-content-efficiency-loading-third-party-javascript)


### PR DESCRIPTION
## Summary

- 광고 슬롯의 `rendered → requested → filled → viewable` 퍼널과 단계별 소요 시간을 수집하도록 계측을 추가했습니다.
- Resource Timing, Long Tasks, `web-vitals/attribution`을 이용해 광고 리소스·Long Task 문맥과 INP/LCP/CLS 세부 정보를 함께 기록합니다.
- fill된 광고 영역이 50% 이상 1초간 노출된 경우만 Viewability로 판정하고, viewport 상하 800px 안의 슬롯만 요청하도록 변경했습니다.
- 슬롯별 요청 중복을 방지하고 예약 크기를 유지하며, AdSense custom channel과 기준선 분석 방법을 문서화했습니다.

## Test plan

- [x] 전체 Vitest 31개 파일, 262개 테스트 통과
- [x] TypeScript `tsc --noEmit` 통과
- [x] 변경 파일 ESLint 및 Prettier 통과
- [x] `git diff --check` 통과
- [x] Next.js 프로덕션 빌드 통과
- [x] 데스크톱·모바일 광고 슬롯 예약 크기 및 콘솔 오류 없음 확인
- [x] preview 환경에서 실제 AdSense 스크립트와 광고 리소스가 로드되지 않음을 확인

Refs #232
