### PR TITLE
[fix] 스킬 빌드 캐시 및 더보기 버튼 크기 조정

### DIFF
--- a/frontend/src/app/api/builds/skills/route.ts
+++ b/frontend/src/app/api/builds/skills/route.ts
@@ -11,6 +11,8 @@ import {
 import { createServerClient } from "@/lib/supabase";
 import { expandCumulativeTier } from "@/utils/tier";
 
+export const revalidate = 1800; // L1: 30분 서버 캐시
+
 export interface CharacterSkillBuildResult {
   skillOrders: SkillOrderChoice[];
   tacticalSkills: TacticalSkillChoice[];

--- a/frontend/src/components/features/character-analysis/CharacterAnalysisClient.tsx
+++ b/frontend/src/components/features/character-analysis/CharacterAnalysisClient.tsx
@@ -263,6 +263,7 @@ export function CharacterAnalysisClient({
     }
   );
   const [loading, setLoading] = React.useState(false);
+  const attemptedPatchFetchesRef = React.useRef<Set<string>>(new Set());
 
   const selectedPatchIndex = selectedPatch ? patches.indexOf(selectedPatch) : 0;
   const selectedPreviousPatch =
@@ -273,6 +274,10 @@ export function CharacterAnalysisClient({
     selectedPatchIndex >= 0 && selectedPreviousPatch
       ? (allPatchStats[selectedPatchIndex + 1] ?? null)
       : null;
+
+  React.useEffect(() => {
+    attemptedPatchFetchesRef.current.clear();
+  }, [code, selectedPatch, selectedTier]);
 
   React.useEffect(() => {
     if (!selectablePatches.length) return;
@@ -372,6 +377,10 @@ export function CharacterAnalysisClient({
     const hasPreviousPatchStats =
       !selectedPreviousPatch || Boolean(allPatchStats[selectedPatchIndex + 1]);
     if (hasSelectedPatchStats && hasPreviousPatchStats) return;
+
+    const requestKey = `${code}:${selectedTier}:${selectedPatch}:${selectedPreviousPatch ?? ""}`;
+    if (attemptedPatchFetchesRef.current.has(requestKey)) return;
+    attemptedPatchFetchesRef.current.add(requestKey);
 
     const fetchSelectedPatch = async () => {
       setLoading(true);

--- a/frontend/src/components/features/character-analysis/CharacterAnalysisClient.tsx
+++ b/frontend/src/components/features/character-analysis/CharacterAnalysisClient.tsx
@@ -770,7 +770,7 @@ export function CharacterAnalysisClient({
                               return next;
                             })
                           }
-                          className="mt-2 flex min-h-9 w-full items-center justify-center gap-1.5 rounded-md text-xs font-semibold text-[var(--color-muted-foreground)] transition-colors hover:bg-[var(--color-surface)] hover:text-[var(--color-foreground)]"
+                          className="mt-2 flex min-h-9 w-full items-center justify-center gap-1.5 rounded-md text-xs! font-semibold text-[var(--color-muted-foreground)] transition-colors hover:bg-[var(--color-surface)] hover:text-[var(--color-foreground)]"
                         >
                           {signaturesExpanded
                             ? characterHeaderT("collapseSignatures")


### PR DESCRIPTION
## 변경 사항
- 스킬 빌드 API에 `revalidate = 1800`을 추가해 장비·특성 빌드 API와 Route Handler 캐시 정책을 통일했습니다.
- 기존 `daily` HTTP 캐시 정책은 유지했습니다.
- 전역 `button { font: inherit; }`에 덮이던 대표 추천 조합 더보기 버튼의 `text-xs`를 우선 적용해 실제 폰트 크기를 16px에서 12px로 조정했습니다.

## 검증
- ESLint: 변경된 Route Handler 및 컴포넌트 통과
- Local API: 스킬 빌드 API 200 응답 및 `max-age=300, s-maxage=1800, stale-while-revalidate=300` 확인
- Playwright: 더보기 버튼 computed style `font-size: 12px`, `line-height: 16px` 확인

Closes #237